### PR TITLE
[FE]  GenreCard 컴포넌트 구현

### DIFF
--- a/client/src/components/molecules/GenreCard/GenreCard.tsx
+++ b/client/src/components/molecules/GenreCard/GenreCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components';
+import Text from '@components/atoms/Text/Text';
+
+const Card = styled.div`
+    display: flex; 
+    align-items: center;
+    height: 60px;
+    padding: 0 9px;
+    color: #232323;
+    text-align: left;
+    border-radius: 4px;
+    background-color: #ececec;
+`;
+
+const Bar = styled.div`
+    width: 4px;
+    height: 42px;
+    border-radius: 3px;
+    background-color: ${(props) => props.color};
+`;
+
+const Content = styled.div`
+    padding: 0 15px;
+`;
+
+interface GenreCardProps {
+    title: string;
+    href: string;
+    color: string;
+}
+
+const GenreCard = ({ title, href, color }: GenreCardProps) => (
+  <Card>
+    {/* TODO : Link 컴포넌트로 감싸기 */}
+    {/* <Link href={href}/> */}
+    <Bar color={color} />
+    <Content>
+      <Text>
+        {title}
+      </Text>
+    </Content>
+  </Card>
+);
+
+export default GenreCard;

--- a/client/src/components/molecules/GenreCard/index.tsx
+++ b/client/src/components/molecules/GenreCard/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './GenreCard';


### PR DESCRIPTION

### 📕 Issue Number

Close #70 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] title, href, color를 props로 받는 molecules 장르 카드 구현


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현재 Next / React Router가 적용되지 않아 Link 컴포넌트 사용하지 못하는 상태라 추후에 Link 컴포넌트에 href 속성 전달할 예정 ( 현재 eslint 에러 발생)

<br/><br/>
