### PR TITLE
[FE] button size 를 props로 받도록 수정

### DIFF
--- a/client/components/atoms/Button/Button.styles.tsx
+++ b/client/components/atoms/Button/Button.styles.tsx
@@ -24,6 +24,8 @@ const getButtonStyle = (props: StyledButtonProps) => {
     color: ${color};
     border: 1px solid ${borderColor};
     background-color: ${backgroundColor};
+    width: ${props.width}px;
+    height: ${props.height}px;
   `;
 };
 

--- a/client/components/atoms/Button/Button.tsx
+++ b/client/components/atoms/Button/Button.tsx
@@ -7,16 +7,18 @@ interface ButtonProps {
     icon?: ComponentType;
     onClick?: (e: MouseEvent<HTMLElement>) => void;
     variant?: 'primary';
+    width?: string;
+    height?: string;
 }
 
 const IconWrapper = styled.div`
-    margin-right: 10px;
+    margin-right: 3px;
 `;
 
 const Button = ({
-  children, onClick, icon: Icon, variant,
+  children, onClick, icon: Icon, variant, width, height
 }: ButtonProps) => (
-  <StyledButton variant={variant} onClick={onClick}>
+  <StyledButton variant={variant} onClick={onClick} width={width} height={height} >
     { Icon && (
     <IconWrapper>
       <Icon />

--- a/client/components/organisms/LibraryHeader/LibraryHeader.stories.tsx
+++ b/client/components/organisms/LibraryHeader/LibraryHeader.stories.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import LibraryHeader from "./LibraryHeader"
+
+export default {
+  title: "LibraryHeader",
+  component: LibraryHeader,
+}
+
+const STORY_SORT = ['mixtape', 'track', 'artist', 'album', 'playlist'];
+
+export const Mixtape = () => <LibraryHeader sort = {STORY_SORT[0]}/>
+export const Track = () => <LibraryHeader sort = {STORY_SORT[1]}/>
+export const Artist = () => <LibraryHeader sort = {STORY_SORT[2]}/>
+export const Album = () => <LibraryHeader sort = {STORY_SORT[3]}/>
+export const Playlist = () => <LibraryHeader sort = {STORY_SORT[4]}/>

--- a/client/components/organisms/LibraryHeader/LibraryHeader.tsx
+++ b/client/components/organisms/LibraryHeader/LibraryHeader.tsx
@@ -1,0 +1,59 @@
+import Text from '@components/atoms/Text/Text';
+import Button from '@components/atoms/Button/Button';
+import styled from 'styled-components';
+import ShuffleIcon from '@material-ui/icons/Shuffle';
+import PlayArrowIcon from '@material-ui/icons/PlayArrow';
+
+const HeaderContainter = styled.div`
+    display: flex;
+    border-bottom: 1px #d7d7d7 solid;
+    width: 960px;
+    height: 80px;
+    background-color: white;
+    padding: 10px 0 0 0;
+`;
+
+const TextContainer = styled.div`
+    display: flex;
+    flex-flow: column;
+    width: 50%;
+`;
+
+const ButtonContainer = styled.div`
+    display: flex;
+    width: 50%;
+    align-items: center;
+    justify-content: flex-end;
+    
+`;
+
+interface LibraryHeaderProps {
+    sort: 'mixtape' | 'track' | 'artist' | 'album' | 'playlist'
+}
+
+const headerTitle = (sort) => {
+    let res;
+    sort === 'mixtape' ? res = '오늘 들을 믹스테잎' :
+    sort === 'track' ? res = '노래' :
+    sort === 'artist' ? res = '아티스트' :
+    sort === 'album' ? res = '앨범' :
+    sort === 'playlist' ? res = '플레이리스트' :
+    res = "sort is wrong"
+
+    return res;
+}
+
+const LibraryHeader = ({sort}: LibraryHeaderProps) => (
+    <HeaderContainter>
+        <TextContainer>
+            <Text variant="primary">보관함</Text>
+            <Text variant="tertiary">{headerTitle(sort)}</Text>
+        </TextContainer>
+        { sort === 'track' && <ButtonContainer>
+            <Button variant = "primary" width='130' height='40' icon={PlayArrowIcon} >전체재생</Button>
+            <Button width='130' height='40' icon={ShuffleIcon}>랜덤재생</Button>
+        </ButtonContainer>}
+    </HeaderContainter>
+);
+
+export default LibraryHeader;


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 1 props로 버튼의 width & height를 string으로 받도록 수정했습니다. (단위: px)
- [ ] 작업 내역 2
- [ ] 작업 내역 3
- [ ] 작업 내역 4


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br/><br/>
