### PR TITLE
장르카드, 매거진, 스테이션 리스트 구현

### DIFF
--- a/client/components/molecules/GenreCard/GenreCard.stories.tsx
+++ b/client/components/molecules/GenreCard/GenreCard.stories.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import GenreCard from "./GenreCard"
+import React from 'react';
+import GenreCard from './GenreCard';
 
 export default {
-  title: "GenreCard",
-  component: GenreCard,
-}
+    title: 'GenreCard',
+    component: GenreCard,
+};
 
-const STORY_GENRE_TITLE = ["K-POP", "해외 힙합"];
-const STORY_HREF = "localhost:3000";
+const STORY_GENRE_TITLE = ['K-POP', '해외 힙합'];
+const STORY_HREF = 'localhost:3000';
 
-export const Default = () => <GenreCard color = "pink" title = {STORY_GENRE_TITLE[0]} href = {STORY_HREF} />
+export const Default = () => <GenreCard color="pink" title={STORY_GENRE_TITLE[0]} href={STORY_HREF} />;
 
-export const Selected = () => <GenreCard color = "black" title = {STORY_GENRE_TITLE[1]} href = {STORY_HREF} />
+export const Selected = () => <GenreCard color="black" title={STORY_GENRE_TITLE[1]} href={STORY_HREF} />;

--- a/client/components/molecules/GenreCard/GenreCard.tsx
+++ b/client/components/molecules/GenreCard/GenreCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Text from '../../atoms/Text/Text';
 
 const Card = styled.div`
-    display: flex; 
+    display: flex;
     align-items: center;
     height: 60px;
     padding: 0 9px;
@@ -11,6 +11,7 @@ const Card = styled.div`
     text-align: left;
     border-radius: 4px;
     background-color: #ececec;
+    margin-bottom: 12px;
 `;
 
 const Bar = styled.div`
@@ -31,16 +32,14 @@ interface GenreCardProps {
 }
 
 const GenreCard = ({ title, href, color }: GenreCardProps) => (
-  <Card>
-    {/* TODO : Link 컴포넌트로 감싸기 */}
-    {/* <Link href={href}/> */}
-    <Bar color={color} />
-    <Content>
-      <Text>
-        {title}
-      </Text>
-    </Content>
-  </Card>
+    <Card>
+        {/* TODO : Link 컴포넌트로 감싸기 */}
+        {/* <Link href={href}/> */}
+        <Bar color={color} />
+        <Content>
+            <Text>{title}</Text>
+        </Content>
+    </Card>
 );
 
 export default GenreCard;

--- a/client/components/organisms/CardLists/GenreCardList/GenreCardList.stories.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/GenreCardList.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import GenreCardList from './GenreCardList';
+
+export default {
+    title: 'GenreCardList',
+    component: GenreCardList,
+};
+
+export const Default = () => <GenreCardList />;

--- a/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
@@ -2,6 +2,20 @@ import React from 'react';
 import styled from 'styled-components';
 import GenreCard from '@components/molecules/GenreCard/GenreCard';
 
+// TODO : DB 에서 장르 내용 받아오기
+const cards = [];
+for (let i = 0; i < 15; i++) {
+    const title = `test${i}`;
+    const href = '#';
+    const color = `#${Math.round(Math.random() * 0xffffff).toString(16)}`;
+    const card = {
+        title,
+        href,
+        color,
+    };
+}
+
+// TODO : refactor
 const getCardBundle = (cards) => {
     const bundle = [];
 

--- a/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
@@ -17,6 +17,20 @@ const getCardBundle = (cards) => {
     return bundle;
 };
 
+const StyledListContainer = styled.div`
+    box-sizing: border-box;
+    padding: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+`;
+const CardBundle = styled.div`
+    width: 180px;
+    display: inline-block;
+    box-sizing: border-box;
+    margin-right: 16px;
+`;
+
 const GenreCardList = () => <StyledListContainer>{getCardBundle(cards)}</StyledListContainer>;
 
 export default GenreCardList;

--- a/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
@@ -4,7 +4,7 @@ import GenreCard from '@components/molecules/GenreCard/GenreCard';
 
 // TODO : DB 에서 장르 내용 받아오기
 const cards = [];
-for (let i = 0; i < 15; i++) {
+for (let i = 0; i < 13; i++) {
     const title = `test${i}`;
     const href = '#';
     const color = `#${Math.round(Math.random() * 0xffffff).toString(16)}`;
@@ -13,6 +13,7 @@ for (let i = 0; i < 15; i++) {
         href,
         color,
     };
+    cards.push(card);
 }
 
 // TODO : refactor
@@ -23,8 +24,12 @@ const getCardBundle = (cards) => {
         bundle.push(
             <CardBundle>
                 <GenreCard title={cards[i].title} href={cards[i].href} color={cards[i].color} />
-                <GenreCard title={cards[i + 1].title} href={cards[i + 1].href} color={cards[i + 1].color} />
-                <GenreCard title={cards[i + 2].title} href={cards[i + 2].href} color={cards[i + 2].color} />
+                {cards[i + 1] ? (
+                    <GenreCard title={cards[i + 1].title} href={cards[i + 1].href} color={cards[i + 1].color} />
+                ) : null}
+                {cards[i + 2] ? (
+                    <GenreCard title={cards[i + 2].title} href={cards[i + 2].href} color={cards[i + 2].color} />
+                ) : null}
             </CardBundle>,
         );
     }
@@ -43,6 +48,7 @@ const CardBundle = styled.div`
     display: inline-block;
     box-sizing: border-box;
     margin-right: 16px;
+    vertical-align: top;
 `;
 
 const GenreCardList = () => <StyledListContainer>{getCardBundle(cards)}</StyledListContainer>;

--- a/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import styled from 'styled-components';
+import GenreCard from '@components/molecules/GenreCard/GenreCard';
+
+const GenreCardList = () => (
+    <StyledListContainer>
+        <GenreCard />
+    </StyledListContainer>
+);
+
+export default GenreCardList;

--- a/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/GenreCardList.tsx
@@ -2,10 +2,21 @@ import React from 'react';
 import styled from 'styled-components';
 import GenreCard from '@components/molecules/GenreCard/GenreCard';
 
-const GenreCardList = () => (
-    <StyledListContainer>
-        <GenreCard />
-    </StyledListContainer>
-);
+const getCardBundle = (cards) => {
+    const bundle = [];
+
+    for (let i = 0; i < cards.length; i += 3) {
+        bundle.push(
+            <CardBundle>
+                <GenreCard title={cards[i].title} href={cards[i].href} color={cards[i].color} />
+                <GenreCard title={cards[i + 1].title} href={cards[i + 1].href} color={cards[i + 1].color} />
+                <GenreCard title={cards[i + 2].title} href={cards[i + 2].href} color={cards[i + 2].color} />
+            </CardBundle>,
+        );
+    }
+    return bundle;
+};
+
+const GenreCardList = () => <StyledListContainer>{getCardBundle(cards)}</StyledListContainer>;
 
 export default GenreCardList;

--- a/client/components/organisms/CardLists/MagazineList/MagazineList.stories.tsx
+++ b/client/components/organisms/CardLists/MagazineList/MagazineList.stories.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import MagazineList from './MagazineList';
-
+import { MagazineSort } from '@interfaces/props';
 export default {
     title: 'MagazineList',
     component: MagazineList,
 };
+const Magazinesdata = Array(9).fill({
+    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
+    href: 'localhost:3000',
+    title: `이 주의 디깅 #77 
+    이영지 새 앨범 발표`,
+    date: '2020.11.25',
+    sort: MagazineSort.main,
+});
 
-export const Defalut = () => <MagazineList />;
+export const Defalut = () => <MagazineList items={Magazinesdata} />;

--- a/client/components/organisms/CardLists/MagazineList/MagazineList.stories.tsx
+++ b/client/components/organisms/CardLists/MagazineList/MagazineList.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import MagazineList from './MagazineList';
+
+export default {
+    title: 'MagazineList',
+    component: MagazineList,
+};
+
+export const Defalut = () => <MagazineList />;

--- a/client/components/organisms/CardLists/MagazineList/MagazineList.tsx
+++ b/client/components/organisms/CardLists/MagazineList/MagazineList.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import MagazineCard from '@components/organisms/Cards/MagazineCard';
+import { MagazineCardProps } from '@interfaces/props';
+interface MagazineListProps {
+    items: MagazineCardProps[];
+}
+
+const MagazineList = ({ items }: MagazineListProps) => (
+    <ul>
+        {items.map((item) => (
+            <li>
+                <MagazineCard {...(item as MagazineCardProps)} />
+            </li>
+        ))}
+    </ul>
+);
+
+export default MagazineList;

--- a/client/components/organisms/CardLists/MagazineList/MagazineList.tsx
+++ b/client/components/organisms/CardLists/MagazineList/MagazineList.tsx
@@ -1,18 +1,30 @@
 import React from 'react';
+import styled from 'styled-components';
 import MagazineCard from '@components/organisms/Cards/MagazineCard';
 import { MagazineCardProps } from '@interfaces/props';
 interface MagazineListProps {
     items: MagazineCardProps[];
 }
-
+const ListContainer = styled.ul`
+    list-style: none;
+    padding: 0;
+    overflow: hidden;
+`;
+const StyledList = styled.li`
+    float: left;
+    width: 33.333333%;
+    margin: 0;
+    box-sizing: border-box;
+    padding: 0 17px 39px 0;
+`;
 const MagazineList = ({ items }: MagazineListProps) => (
-    <ul>
+    <ListContainer>
         {items.map((item) => (
-            <li>
+            <StyledList>
                 <MagazineCard {...(item as MagazineCardProps)} />
-            </li>
+            </StyledList>
         ))}
-    </ul>
+    </ListContainer>
 );
 
 export default MagazineList;

--- a/client/components/organisms/CardLists/StationCardList/StationCard.stories.tsx
+++ b/client/components/organisms/CardLists/StationCardList/StationCard.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import StationCardList from './StationCardList';
+
+export default {
+    title: 'StationCardList',
+    component: StationCardList,
+};
+
+const StationCards = Array(20).fill({
+    src: 'https://music-phinf.pstatic.net/20181204_11/1543918826895DFvFt_PNG/mood_3_Happy.png?type=f360',
+    href: '#',
+    sort: '',
+});
+
+export const Default = () => <StationCardList items={StationCards} />;

--- a/client/components/organisms/CardLists/StationCardList/StationCardList.tsx
+++ b/client/components/organisms/CardLists/StationCardList/StationCardList.tsx
@@ -1,18 +1,32 @@
 import React from 'react';
+import styled from 'styled-components';
 import { StationCardProps } from '@interfaces/props';
 import StationCard from '@components/organisms/Cards/StationCard/StationCard';
 
 interface StationCardListProps {
     items: StationCardProps[];
 }
+const ListContainer = styled.ul`
+    margin: 0;
+    list-style: none;
+    padding: 0;
+    overflow: hidden;
+`;
+
+const StyledList = styled.li`
+    box-sizing: border-box;
+    float: left;
+    padding: 0 16px 16px 0;
+    width: 196px;
+`;
 const StationCardList = ({ items }: StationCardListProps) => (
-    <ul>
+    <ListContainer>
         {items.map((item) => (
-            <li>
+            <StyledList>
                 <StationCard {...(item as StationCardProps)} />
-            </li>
+            </StyledList>
         ))}
-    </ul>
+    </ListContainer>
 );
 
 export default StationCardList;

--- a/client/components/organisms/CardLists/StationCardList/StationCardList.tsx
+++ b/client/components/organisms/CardLists/StationCardList/StationCardList.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StationCardProps } from '@interfaces/props';
+import StationCard from '@components/organisms/Cards/StationCard/StationCard';
+
+interface StationCardListProps {
+    items: StationCardProps[];
+}
+const StationCardList = ({ items }: StationCardListProps) => (
+    <ul>
+        {items.map((item) => (
+            <li>
+                <StationCard {...(item as StationCardProps)} />
+            </li>
+        ))}
+    </ul>
+);
+
+export default StationCardList;

--- a/client/components/organisms/Cards/MagazineCard/MagazineCard.tsx
+++ b/client/components/organisms/Cards/MagazineCard/MagazineCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import ContentsThumbnail from '@components/molecules/ContentsThumbnail/ContentsThumbnail';
 import A from '@components/atoms/A/A';
 import Text from '@components/atoms/Text/Text';
-
+import { MagazineCardProps } from '@interfaces/props';
 const CardContainer = styled.div`
     display: flex;
     flex-flow: column;
@@ -11,8 +11,7 @@ const CardContainer = styled.div`
     height: 382px;
 `;
 
-const ThumbnailContainer = styled.div`
-`;
+const ThumbnailContainer = styled.div``;
 
 const TextContainer = styled.div`
     display: flex;
@@ -34,28 +33,20 @@ const StyledA = styled(A)`
     font-size: 16px;
 `;
 
-interface MagazineCardProps {
-    src: string,
-    href: string,
-    title: string,
-    date: string,
-    sort: 'todayMagazine' | 'normalMagazine'
-};
-
-const MagazineCard = ( { title, date, src, href, sort }: MagazineCardProps ) => (
-    <CardContainer sort = {sort}>
+const MagazineCard = ({ title, date, src, href, sort }: MagazineCardProps) => (
+    <CardContainer sort={sort}>
         <ThumbnailContainer>
-            <ContentsThumbnail src = {src} href = {href} sort = {sort} />
+            <ContentsThumbnail src={src} href={href} sort={sort} />
         </ThumbnailContainer>
         <TextContainer>
             <TitelContainer>
                 <StyledA href={href}>{title}</StyledA>
             </TitelContainer>
             <DescriptionContainer>
-                <Text variant = "primary">{date}</Text>
+                <Text variant="primary">{date}</Text>
             </DescriptionContainer>
         </TextContainer>
     </CardContainer>
-)
+);
 
 export default MagazineCard;

--- a/client/components/organisms/Cards/StationCard/StationCard.tsx
+++ b/client/components/organisms/Cards/StationCard/StationCard.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import ContentsThumbnail from '@components/molecules/ContentsThumbnail/ContentsThumbnail';
+import { StationCardProps } from '@interfaces/props';
 import A from '@components/atoms/A/A';
 import Text from '@components/atoms/Text/Text';
 
@@ -11,20 +12,14 @@ const CardContainer = styled.div`
     height: 180px;
 `;
 
-const ThumbnailContainer = styled.div`
-`;
+const ThumbnailContainer = styled.div``;
 
-interface StationCardProps {
-    src: string,
-    href: string,
-};
-
-const StationCard = ( { src }: StationCardProps ) => (
-    <CardContainer >
+const StationCard = ({ src }: StationCardProps) => (
+    <CardContainer>
         <ThumbnailContainer>
-            <ContentsThumbnail src = {src} href = "" sort = "" />
+            <ContentsThumbnail src={src} href="" sort="" />
         </ThumbnailContainer>
     </CardContainer>
-)
+);
 
 export default StationCard;

--- a/client/interfaces/props.ts
+++ b/client/interfaces/props.ts
@@ -17,3 +17,10 @@ export interface NewsCardProps {
     newsHref: string,
     title: string,
 };
+export interface MagazineCardProps {
+    src: string,
+    href: string,
+    title: string,
+    date: string,
+    sort: 'todayMagazine' | 'normalMagazine'
+};

--- a/client/interfaces/props.ts
+++ b/client/interfaces/props.ts
@@ -24,3 +24,8 @@ export interface MagazineCardProps {
     date: string,
     sort: 'todayMagazine' | 'normalMagazine'
 };
+
+export interface StationCardProps {
+    src: string,
+    href: string,
+};


### PR DESCRIPTION
### 📕 Issue Number

Close #159 #161 #163 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 장르 카드들 리스트 형태로 랜더링
- [x] 리스트에 styled-components 추가 및 적용 
- [x] 장르 카드들에 대한 dummy 데이터 생성
- [x] 카드들을 3개씩 묶는 번들링 함수 구현
- [x] 매거진 카드 랜더링
- [x] 매거진 리스트 styled-components 추가 및 적용
- [x] 스테이션 카드 랜더링
- [x] 스테이션 카드 리스트 styled-components 추가 및 적용

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- getCardBundle 리팩토링 하고 싶은 아이디어가 떠오르지 않습니다..

<br/><br/>
