### PR TITLE
[iOS] 재생화면 곡 정보 표시 뷰 구현 #109, #112, #114

### DIFF
--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		445919A4256E4A6F0069DAB2 /* ThumbnailGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919A3256E4A6F0069DAB2 /* ThumbnailGrid.swift */; };
 		445919AD256E559D0069DAB2 /* StationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919AC256E559D0069DAB2 /* StationList.swift */; };
 		445919B1256E5CEA0069DAB2 /* StationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919B0256E5CEA0069DAB2 /* StationStack.swift */; };
+		4474DBFD2574DF78006FC827 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFC2574DF78006FC827 /* Player.swift */; };
 		4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */; };
 		4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */; };
 		4474DC062574E8DB006FC827 /* PlayerSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DC052574E8DB006FC827 /* PlayerSlider.swift */; };
@@ -66,6 +67,7 @@
 		445919A3256E4A6F0069DAB2 /* ThumbnailGrid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailGrid.swift; sourceTree = "<group>"; };
 		445919AC256E559D0069DAB2 /* StationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationList.swift; sourceTree = "<group>"; };
 		445919B0256E5CEA0069DAB2 /* StationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationStack.swift; sourceTree = "<group>"; };
+		4474DBFC2574DF78006FC827 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerHeader.swift; sourceTree = "<group>"; };
 		4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerThumbnail.swift; sourceTree = "<group>"; };
 		4474DC052574E8DB006FC827 /* PlayerSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSlider.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 			children = (
 				4421992D256E7AA800ECF4A0 /* Common */,
 				44219931256E7B2300ECF4A0 /* Today */,
+				4474DBFC2574DF78006FC827 /* Player.swift */,
 				4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */,
 				4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */,
 				4474DC052574E8DB006FC827 /* PlayerSlider.swift */,
@@ -394,6 +397,7 @@
 				4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */,
 				444272B8256CE2B3008BB87B /* PreviewItem.swift in Sources */,
 				444272B3256CDEC8008BB87B /* TodayTitle.swift in Sources */,
+				4474DBFD2574DF78006FC827 /* Player.swift in Sources */,
 				805E28D3256BDC4A007AF5F1 /* TrackRow.swift in Sources */,
 				80C6207A256CF21600B5C375 /* StationItem.swift in Sources */,
 				8084AB6D256E403900F2AAC2 /* ThumbnailRow.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		445919A4256E4A6F0069DAB2 /* ThumbnailGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919A3256E4A6F0069DAB2 /* ThumbnailGrid.swift */; };
 		445919AD256E559D0069DAB2 /* StationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919AC256E559D0069DAB2 /* StationList.swift */; };
 		445919B1256E5CEA0069DAB2 /* StationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919B0256E5CEA0069DAB2 /* StationStack.swift */; };
+		4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */; };
 		4478AA3A256CDD8F00FDED38 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4478AA39256CDD8F00FDED38 /* .swiftlint.yml */; };
 		4478F717256E817100755656 /* CGFloat+Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F716256E817100755656 /* CGFloat+Constant.swift */; };
 		4478F71C256E858700755656 /* MixtapeGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F71B256E858700755656 /* MixtapeGrid.swift */; };
@@ -61,6 +62,7 @@
 		445919A3256E4A6F0069DAB2 /* ThumbnailGrid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailGrid.swift; sourceTree = "<group>"; };
 		445919AC256E559D0069DAB2 /* StationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationList.swift; sourceTree = "<group>"; };
 		445919B0256E5CEA0069DAB2 /* StationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationStack.swift; sourceTree = "<group>"; };
+		4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerHeader.swift; sourceTree = "<group>"; };
 		4478AA39256CDD8F00FDED38 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		4478F716256E817100755656 /* CGFloat+Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+Constant.swift"; sourceTree = "<group>"; };
 		4478F71B256E858700755656 /* MixtapeGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixtapeGrid.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 			children = (
 				4421992D256E7AA800ECF4A0 /* Common */,
 				44219931256E7B2300ECF4A0 /* Today */,
+				4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				807B698D256FAC2F00DAF867 /* NetworkService.swift in Sources */,
 				445919A4256E4A6F0069DAB2 /* ThumbnailGrid.swift in Sources */,
 				4478F717256E817100755656 /* CGFloat+Constant.swift in Sources */,
+				4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */,
 				444272B8256CE2B3008BB87B /* PreviewItem.swift in Sources */,
 				444272B3256CDEC8008BB87B /* TodayTitle.swift in Sources */,
 				805E28D3256BDC4A007AF5F1 /* TrackRow.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		447BF73B256F3E6C003B5DB7 /* MainTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447BF73A256F3E6C003B5DB7 /* MainTab.swift */; };
 		448FD1CE256F83050027BC57 /* MyMixtape.json in Resources */ = {isa = PBXBuildFile; fileRef = 448FD1CD256F83050027BC57 /* MyMixtape.json */; };
 		44D7B7E725753C2D0049CDBB /* RepeatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E625753C2D0049CDBB /* RepeatButton.swift */; };
+		44D7B7EA25754BF10049CDBB /* PlayerControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E925754BF10049CDBB /* PlayerControls.swift */; };
 		44F97972256CF2AE00C9C224 /* ThumbnailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */; };
 		44F97976256CFBA900C9C224 /* ThumbnailSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97975256CFBA900C9C224 /* ThumbnailSection.swift */; };
 		44F9797C256D04EA00C9C224 /* RecommandedPlayListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F9797B256D04EA00C9C224 /* RecommandedPlayListItem.swift */; };
@@ -76,6 +77,7 @@
 		447BF73A256F3E6C003B5DB7 /* MainTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTab.swift; sourceTree = "<group>"; };
 		448FD1CD256F83050027BC57 /* MyMixtape.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MyMixtape.json; sourceTree = "<group>"; };
 		44D7B7E625753C2D0049CDBB /* RepeatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatButton.swift; sourceTree = "<group>"; };
+		44D7B7E925754BF10049CDBB /* PlayerControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControls.swift; sourceTree = "<group>"; };
 		44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailItem.swift; sourceTree = "<group>"; };
 		44F97975256CFBA900C9C224 /* ThumbnailSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailSection.swift; sourceTree = "<group>"; };
 		44F9797B256D04EA00C9C224 /* RecommandedPlayListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommandedPlayListItem.swift; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 				4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */,
 				4474DC052574E8DB006FC827 /* PlayerSlider.swift */,
 				44D7B7E625753C2D0049CDBB /* RepeatButton.swift */,
+				44D7B7E925754BF10049CDBB /* PlayerControls.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -376,6 +379,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44D7B7EA25754BF10049CDBB /* PlayerControls.swift in Sources */,
 				805E28DA256BDFE6007AF5F1 /* ChartSection.swift in Sources */,
 				44F97972256CF2AE00C9C224 /* ThumbnailItem.swift in Sources */,
 				4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		4478F723256E8B2B00755656 /* PlayAndShuffle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F722256E8B2B00755656 /* PlayAndShuffle.swift */; };
 		447BF73B256F3E6C003B5DB7 /* MainTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447BF73A256F3E6C003B5DB7 /* MainTab.swift */; };
 		448FD1CE256F83050027BC57 /* MyMixtape.json in Resources */ = {isa = PBXBuildFile; fileRef = 448FD1CD256F83050027BC57 /* MyMixtape.json */; };
+		44D7B7E725753C2D0049CDBB /* RepeatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E625753C2D0049CDBB /* RepeatButton.swift */; };
 		44F97972256CF2AE00C9C224 /* ThumbnailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */; };
 		44F97976256CFBA900C9C224 /* ThumbnailSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97975256CFBA900C9C224 /* ThumbnailSection.swift */; };
 		44F9797C256D04EA00C9C224 /* RecommandedPlayListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F9797B256D04EA00C9C224 /* RecommandedPlayListItem.swift */; };
@@ -74,6 +75,7 @@
 		4478F722256E8B2B00755656 /* PlayAndShuffle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAndShuffle.swift; sourceTree = "<group>"; };
 		447BF73A256F3E6C003B5DB7 /* MainTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTab.swift; sourceTree = "<group>"; };
 		448FD1CD256F83050027BC57 /* MyMixtape.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MyMixtape.json; sourceTree = "<group>"; };
+		44D7B7E625753C2D0049CDBB /* RepeatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatButton.swift; sourceTree = "<group>"; };
 		44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailItem.swift; sourceTree = "<group>"; };
 		44F97975256CFBA900C9C224 /* ThumbnailSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailSection.swift; sourceTree = "<group>"; };
 		44F9797B256D04EA00C9C224 /* RecommandedPlayListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommandedPlayListItem.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */,
 				4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */,
 				4474DC052574E8DB006FC827 /* PlayerSlider.swift */,
+				44D7B7E625753C2D0049CDBB /* RepeatButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 				4478F71C256E858700755656 /* MixtapeGrid.swift in Sources */,
 				805E28D7256BDE90007AF5F1 /* SectionTitle.swift in Sources */,
 				445919AD256E559D0069DAB2 /* StationList.swift in Sources */,
+				44D7B7E725753C2D0049CDBB /* RepeatButton.swift in Sources */,
 				80EB9FE8256D0AD700CD99FD /* MagazineSection.swift in Sources */,
 				807B698D256FAC2F00DAF867 /* NetworkService.swift in Sources */,
 				445919A4256E4A6F0069DAB2 /* ThumbnailGrid.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		445919B1256E5CEA0069DAB2 /* StationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919B0256E5CEA0069DAB2 /* StationStack.swift */; };
 		4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */; };
 		4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */; };
+		4474DC062574E8DB006FC827 /* PlayerSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DC052574E8DB006FC827 /* PlayerSlider.swift */; };
 		4478AA3A256CDD8F00FDED38 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4478AA39256CDD8F00FDED38 /* .swiftlint.yml */; };
 		4478F717256E817100755656 /* CGFloat+Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F716256E817100755656 /* CGFloat+Constant.swift */; };
 		4478F71C256E858700755656 /* MixtapeGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F71B256E858700755656 /* MixtapeGrid.swift */; };
@@ -65,6 +66,7 @@
 		445919B0256E5CEA0069DAB2 /* StationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationStack.swift; sourceTree = "<group>"; };
 		4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerHeader.swift; sourceTree = "<group>"; };
 		4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerThumbnail.swift; sourceTree = "<group>"; };
+		4474DC052574E8DB006FC827 /* PlayerSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSlider.swift; sourceTree = "<group>"; };
 		4478AA39256CDD8F00FDED38 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		4478F716256E817100755656 /* CGFloat+Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+Constant.swift"; sourceTree = "<group>"; };
 		4478F71B256E858700755656 /* MixtapeGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixtapeGrid.swift; sourceTree = "<group>"; };
@@ -228,6 +230,7 @@
 				44219931256E7B2300ECF4A0 /* Today */,
 				4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */,
 				4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */,
+				4474DC052574E8DB006FC827 /* PlayerSlider.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				805E28AE256BBD52007AF5F1 /* MiniVibeApp.swift in Sources */,
 				447BF73B256F3E6C003B5DB7 /* MainTab.swift in Sources */,
 				44F9797C256D04EA00C9C224 /* RecommandedPlayListItem.swift in Sources */,
+				4474DC062574E8DB006FC827 /* PlayerSlider.swift in Sources */,
 				444272BB256CE701008BB87B /* PreviewSection.swift in Sources */,
 				80EB9FE5256D04A000CD99FD /* MagazineItem.swift in Sources */,
 			);

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		445919AD256E559D0069DAB2 /* StationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919AC256E559D0069DAB2 /* StationList.swift */; };
 		445919B1256E5CEA0069DAB2 /* StationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919B0256E5CEA0069DAB2 /* StationStack.swift */; };
 		4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */; };
+		4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */; };
 		4478AA3A256CDD8F00FDED38 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 4478AA39256CDD8F00FDED38 /* .swiftlint.yml */; };
 		4478F717256E817100755656 /* CGFloat+Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F716256E817100755656 /* CGFloat+Constant.swift */; };
 		4478F71C256E858700755656 /* MixtapeGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F71B256E858700755656 /* MixtapeGrid.swift */; };
@@ -63,6 +64,7 @@
 		445919AC256E559D0069DAB2 /* StationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationList.swift; sourceTree = "<group>"; };
 		445919B0256E5CEA0069DAB2 /* StationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationStack.swift; sourceTree = "<group>"; };
 		4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerHeader.swift; sourceTree = "<group>"; };
+		4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerThumbnail.swift; sourceTree = "<group>"; };
 		4478AA39256CDD8F00FDED38 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		4478F716256E817100755656 /* CGFloat+Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+Constant.swift"; sourceTree = "<group>"; };
 		4478F71B256E858700755656 /* MixtapeGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixtapeGrid.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 				4421992D256E7AA800ECF4A0 /* Common */,
 				44219931256E7B2300ECF4A0 /* Today */,
 				4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */,
+				4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 			files = (
 				805E28DA256BDFE6007AF5F1 /* ChartSection.swift in Sources */,
 				44F97972256CF2AE00C9C224 /* ThumbnailItem.swift in Sources */,
+				4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */,
 				4478F71C256E858700755656 /* MixtapeGrid.swift in Sources */,
 				805E28D7256BDE90007AF5F1 /* SectionTitle.swift in Sources */,
 				445919AD256E559D0069DAB2 /* StationList.swift in Sources */,

--- a/MiniVibe/MiniVibe/Views/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player.swift
@@ -1,0 +1,67 @@
+//
+//  Player.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/11/30.
+//
+
+import SwiftUI
+
+struct Player: View {
+    @State var isPlaying = false
+    
+    var body: some View {
+        VStack {
+            PlayerHeader(title: "오늘 Top 100")
+            
+            Spacer()
+            
+            PlayerThumbnail(image: "playListThumbnail",
+                            lyrics: "가사가사가사가사\n가사가사\n가사\n가사가사가사가사", isPlaying: $isPlaying)
+            
+            Spacer()
+            
+            PlayerControls(isPlaying: $isPlaying)
+                
+            Spacer()
+            
+            footer
+        }
+        .padding(16)
+    }
+    
+    var footer: some View {
+        HStack {
+            Button {
+                
+            } label: {
+                Image(systemName: "airplayaudio")
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Button {
+                
+            } label: {
+                HStack(spacing: 2) {
+                    Text("미리듣기 중")
+                    Image(systemName: "info.circle")
+                }
+                .foregroundColor(.pink)
+                .font(.system(size: 12))
+            }
+            Spacer()
+            Button {
+                
+            } label: {
+                Image(systemName: "music.note.list")
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+struct Player_Previews: PreviewProvider {
+    static var previews: some View {
+        Player()
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player.swift
@@ -30,7 +30,7 @@ struct Player: View {
         .padding(16)
     }
     
-    var footer: some View {
+    private var footer: some View {
         HStack {
             Button {
                 
@@ -38,7 +38,9 @@ struct Player: View {
                 Image(systemName: "airplayaudio")
                     .foregroundColor(.secondary)
             }
+            
             Spacer()
+            
             Button {
                 
             } label: {
@@ -49,7 +51,9 @@ struct Player: View {
                 .foregroundColor(.pink)
                 .font(.system(size: 12))
             }
+            
             Spacer()
+            
             Button {
                 
             } label: {

--- a/MiniVibe/MiniVibe/Views/PlayerControls.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerControls.swift
@@ -1,0 +1,63 @@
+//
+//  PlayerControls.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/12/01.
+//
+
+import SwiftUI
+
+struct PlayerControls: View {
+    @Binding var isPlaying: Bool
+    @State private var isFavorite = false
+    @State private var isShuffle = false
+    
+    var body: some View {
+        VStack {
+            PlayerSlider(title: "노래 제목", artist: "가수 이름")
+                .frame(height: 100)
+            
+            HStack {
+                RepeatButton()
+                Spacer()
+                Button {
+                    
+                } label: {
+                    Image(systemName: "paperplane")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: 28))
+                }
+                Spacer()
+                Button {
+                    isPlaying.toggle()
+                } label: {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .foregroundColor(.black)
+                        .font(.system(size: 40))
+                        .frame(height: 40)
+                }
+                Spacer()
+                Button {
+                    isFavorite.toggle()
+                } label: {
+                    Image(systemName: isFavorite ? "heart.fill" : "heart")
+                        .foregroundColor(isFavorite ? .pink : .secondary)
+                        .font(.system(size: 32))
+                }
+                Spacer()
+                Button {
+                    isShuffle.toggle()
+                } label: {
+                    Image(systemName: "shuffle")
+                        .foregroundColor(isShuffle ? .pink : .secondary)
+                }
+            }
+        }
+    }
+}
+
+struct PlayerControls_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerControls(isPlaying: .constant(false))
+    }
+}

--- a/MiniVibe/MiniVibe/Views/PlayerControls.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerControls.swift
@@ -19,7 +19,9 @@ struct PlayerControls: View {
             
             HStack {
                 RepeatButton()
+                
                 Spacer()
+                
                 Button {
                     
                 } label: {
@@ -27,7 +29,9 @@ struct PlayerControls: View {
                         .foregroundColor(.secondary)
                         .font(.system(size: 28))
                 }
+                
                 Spacer()
+                
                 Button {
                     isPlaying.toggle()
                 } label: {
@@ -36,7 +40,9 @@ struct PlayerControls: View {
                         .font(.system(size: 40))
                         .frame(height: 40)
                 }
+                
                 Spacer()
+                
                 Button {
                     isFavorite.toggle()
                 } label: {
@@ -44,7 +50,9 @@ struct PlayerControls: View {
                         .foregroundColor(isFavorite ? .pink : .secondary)
                         .font(.system(size: 32))
                 }
+                
                 Spacer()
+                
                 Button {
                     isShuffle.toggle()
                 } label: {

--- a/MiniVibe/MiniVibe/Views/PlayerHeader.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerHeader.swift
@@ -1,0 +1,44 @@
+//
+//  PlayerHeader.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/11/30.
+//
+
+import SwiftUI
+
+struct PlayerHeader: View {
+    let title: String
+    
+    var body: some View {
+        HStack {
+            Button {
+                
+            } label: {
+                Image(systemName: "slider.horizontal.3")
+                    .foregroundColor(.black)
+            }
+            
+            Spacer()
+            
+            Text(title)
+            
+            Spacer()
+            
+            Button {
+                
+            } label: {
+                Image(systemName: "chevron.compact.down")
+                    .foregroundColor(.black)
+            }
+        }
+        .padding(8)
+    }
+}
+
+struct PlayerHeader_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerHeader(title: "오늘 Top 100")
+            .previewLayout(.fixed(width: 350, height: 100))
+    }
+}

--- a/MiniVibe/MiniVibe/Views/PlayerSlider.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerSlider.swift
@@ -1,0 +1,98 @@
+//
+//  PlayerSlider.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/11/30.
+//
+
+import SwiftUI
+
+struct PlayerSlider: View {
+    
+    let title: String
+    let artist: String
+    let totalDuration: String = "3:21"
+    @State private var playbackTime: String = "0:00"
+    @State private var percentage: Float = 30
+    @State private var dragAction = false
+    @State private var dragLocation: CGFloat = .zero
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 16) {
+                trackInfo(title: title, artist: artist)
+                
+                VStack(alignment: .leading) {
+                    if dragAction {
+                        Text("\(Int(percentage))")
+                            .foregroundColor(.secondary)
+                            .offset(x: dragLocation)
+                    }
+                    ZStack(alignment: .leading) {
+                        Rectangle()
+                            .foregroundColor(.secondary)
+                        
+                        Rectangle()
+                            .foregroundColor(.pink)
+                            .frame(width: geometry.size.width * CGFloat(percentage / 100))
+                    }
+                    .frame(height: dragAction ? 24: 3)
+                    .cornerRadius(4)
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                
+                                let changedPercentage = Float(
+                                    value.location.x / geometry.size.width * 100
+                                )
+                                percentage = min(max(0, changedPercentage), 100)
+                                dragAction = true
+                                dragLocation = value.location.x
+                            }
+                            .onEnded { _ in
+                                dragAction = false
+                            }
+                    )
+                    HStack {
+                        Text(playbackTime)
+                        Spacer()
+                        Text(totalDuration)
+                    }
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 12))
+                }
+                .offset(y: dragAction ? -40 : 0)
+                .animation(.easeInOut)
+            }
+        }
+    }
+    
+    private func trackInfo(title: String, artist: String) -> some View {
+        VStack(alignment: .leading,
+               spacing: 3) {
+            Text(title)
+                .font(.system(size: 20, weight: .bold))
+            
+            HStack {
+                Text(artist)
+                    .font(.system(size: 16))
+                    .foregroundColor(.secondary)
+                
+                Spacer()
+                
+                Button {
+                    
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .foregroundColor(.black)
+                }
+            }
+        }
+    }
+}
+
+struct PlayerSlider_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerSlider(title: "노래 제목", artist: "가수 이름")
+    }
+}

--- a/MiniVibe/MiniVibe/Views/PlayerSlider.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerSlider.swift
@@ -28,6 +28,7 @@ struct PlayerSlider: View {
                             .foregroundColor(.secondary)
                             .offset(x: dragLocation)
                     }
+                    
                     ZStack(alignment: .leading) {
                         Rectangle()
                             .foregroundColor(.secondary)
@@ -41,7 +42,6 @@ struct PlayerSlider: View {
                     .gesture(
                         DragGesture(minimumDistance: 0)
                             .onChanged { value in
-                                
                                 let changedPercentage = Float(
                                     value.location.x / geometry.size.width * 100
                                 )
@@ -55,7 +55,9 @@ struct PlayerSlider: View {
                     )
                     HStack {
                         Text(playbackTime)
+                        
                         Spacer()
+                        
                         Text(totalDuration)
                     }
                     .foregroundColor(.secondary)

--- a/MiniVibe/MiniVibe/Views/PlayerThumbnail.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerThumbnail.swift
@@ -18,6 +18,7 @@ struct PlayerThumbnail: View {
                 .resizable()
                 .aspectRatio(1, contentMode: .fit)
                 .scaleEffect(isPlaying ? 1 : 0.9)
+            
             Text(lyrics)
                 .font(.system(size: 14))
                 .foregroundColor(.secondary)

--- a/MiniVibe/MiniVibe/Views/PlayerThumbnail.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerThumbnail.swift
@@ -10,24 +10,27 @@ import SwiftUI
 struct PlayerThumbnail: View {
     let image: String
     let lyrics: String
+    @Binding var isPlaying: Bool
     
     var body: some View {
         VStack {
             Image(image)
                 .resizable()
                 .aspectRatio(1, contentMode: .fit)
+                .scaleEffect(isPlaying ? 1 : 0.9)
             Text(lyrics)
-                .font(.system(size: 12))
+                .font(.system(size: 14))
                 .foregroundColor(.secondary)
                 .lineLimit(2)
+                .opacity(isPlaying ? 1 : 0)
         }
-        .padding(.vertical, 24)
+        .animation(.easeInOut)
     }
 }
 
 struct PlayerThumbnail_Previews: PreviewProvider {
     static var previews: some View {
         PlayerThumbnail(image: "playListThumbnail",
-                        lyrics: "가사가사가사가사\n가사가사\n가사\n가사가사가사가사")
+                        lyrics: "가사가사가사가사\n가사가사\n가사\n가사가사가사가사", isPlaying: .constant(false))
     }
 }

--- a/MiniVibe/MiniVibe/Views/PlayerThumbnail.swift
+++ b/MiniVibe/MiniVibe/Views/PlayerThumbnail.swift
@@ -1,0 +1,33 @@
+//
+//  PlayerThumbnail.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/11/30.
+//
+
+import SwiftUI
+
+struct PlayerThumbnail: View {
+    let image: String
+    let lyrics: String
+    
+    var body: some View {
+        VStack {
+            Image(image)
+                .resizable()
+                .aspectRatio(1, contentMode: .fit)
+            Text(lyrics)
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+        }
+        .padding(.vertical, 24)
+    }
+}
+
+struct PlayerThumbnail_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerThumbnail(image: "playListThumbnail",
+                        lyrics: "가사가사가사가사\n가사가사\n가사\n가사가사가사가사")
+    }
+}

--- a/MiniVibe/MiniVibe/Views/RepeatButton.swift
+++ b/MiniVibe/MiniVibe/Views/RepeatButton.swift
@@ -1,0 +1,53 @@
+//
+//  RepeatButton.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/11/30.
+//
+
+import SwiftUI
+
+struct RepeatButton: View {
+    enum RepeatType {
+        case none
+        case `repeat`
+        case repeatOne
+        
+        var imageName: String {
+            switch self {
+            case .none, .repeat:
+                return "repeat"
+            case .repeatOne:
+                return "repeat.1"
+            }
+        }
+        
+        mutating func next() {
+            switch self {
+            case .none:
+                self = .repeat
+            case .repeat:
+                self = .repeatOne
+            case .repeatOne:
+                self = .none
+            }
+        }
+    }
+    
+    @State private var type = RepeatType.none
+    
+    var body: some View {
+        Button {
+            type.next()
+        } label: {
+            Image(systemName: type.imageName)
+                .foregroundColor(type == .none ? .secondary : .pink)
+        }
+    }
+}
+
+struct RepeatButton_Previews: PreviewProvider {
+    static var previews: some View {
+        RepeatButton()
+    }
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #109 
Close #112 
Close #114 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 현재 재생되고 있는 음원의 앨범자켓, 제목, 가수를 표시
- [x] 슬라이더를 드래그 할 때 슬라이더의 크기를 키우고 드래그 이벤트 발생 지점에 슬라이더의 값 표시(분:초 형태로 변환 필요)
- [x] 음원을 재생하면 앨범자켓의 크기를 키우고 가사를 표시

![player](https://user-images.githubusercontent.com/50410213/100638474-6a270900-3377-11eb-8017-99c8cd28de0a.gif)



### 📘 작업 유형

- [x] 신규 기능 추가


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

