### PR TITLE
[iOS] 앨범 메뉴 화면 구현 #142

### DIFF
--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		44056D152575DD5100BF8337 /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44056D142575DD5100BF8337 /* PlayerView.swift */; };
+		440D023225779A7F00477A7D /* AlbumMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440D023125779A7F00477A7D /* AlbumMenu.swift */; };
+		440D023625779C4F00477A7D /* MenuThumbnailButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440D023525779C4F00477A7D /* MenuThumbnailButton.swift */; };
+		440D023A2577A3E500477A7D /* MenuCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440D02392577A3E500477A7D /* MenuCloseButton.swift */; };
 		441357EA25764C8900DC0746 /* ArtistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441357E925764C8900DC0746 /* ArtistView.swift */; };
 		44139C81257607D3000CEEA5 /* MenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44139C80257607D3000CEEA5 /* MenuButton.swift */; };
 		44139C9D25762D17000CEEA5 /* ArtistSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44139C9C25762D17000CEEA5 /* ArtistSection.swift */; };
@@ -88,6 +91,9 @@
 
 /* Begin PBXFileReference section */
 		44056D142575DD5100BF8337 /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		440D023125779A7F00477A7D /* AlbumMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumMenu.swift; sourceTree = "<group>"; };
+		440D023525779C4F00477A7D /* MenuThumbnailButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuThumbnailButton.swift; sourceTree = "<group>"; };
+		440D02392577A3E500477A7D /* MenuCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCloseButton.swift; sourceTree = "<group>"; };
 		441357E925764C8900DC0746 /* ArtistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistView.swift; sourceTree = "<group>"; };
 		44139C80257607D3000CEEA5 /* MenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButton.swift; sourceTree = "<group>"; };
 		44139C9C25762D17000CEEA5 /* ArtistSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSection.swift; sourceTree = "<group>"; };
@@ -343,8 +349,11 @@
 			isa = PBXGroup;
 			children = (
 				44139C80257607D3000CEEA5 /* MenuButton.swift */,
+				440D023525779C4F00477A7D /* MenuThumbnailButton.swift */,
+				440D02392577A3E500477A7D /* MenuCloseButton.swift */,
 				441EC83F2576031F0069146E /* PlayerMenu.swift */,
 				80045E0D25762C1100F32E6C /* ArtistMenu.swift */,
+				440D023125779A7F00477A7D /* AlbumMenu.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -607,6 +616,7 @@
 				80045DFA257602A900F32E6C /* Lyrics.swift in Sources */,
 				44139CBB25763C5F000CEEA5 /* ThumbnailGrid.swift in Sources */,
 				80045E0E25762C1100F32E6C /* ArtistMenu.swift in Sources */,
+				440D023A2577A3E500477A7D /* MenuCloseButton.swift in Sources */,
 				44141E712577841A00A82626 /* ProfileView.swift in Sources */,
 				441EC8402576031F0069146E /* PlayerMenu.swift in Sources */,
 				80EB9FF5256DE8A300CD99FD /* Today.swift in Sources */,
@@ -617,8 +627,10 @@
 				4478F723256E8B2B00755656 /* PlayAndShuffle.swift in Sources */,
 				44F97976256CFBA900C9C224 /* ThumbnailSection.swift in Sources */,
 				80FA442F25763DE00092D25D /* AlbumPlaylistView.swift in Sources */,
+				440D023225779A7F00477A7D /* AlbumMenu.swift in Sources */,
 				80ABC18D2574DFDE003D4666 /* UpNextList.swift in Sources */,
 				8084AB70256E409B00F2AAC2 /* ThumbnailList.swift in Sources */,
+				440D023625779C4F00477A7D /* MenuThumbnailButton.swift in Sources */,
 				8087AC7B256F3E4D001F6369 /* PlayerPreview.swift in Sources */,
 				80045DDF25758C5A00F32E6C /* MultiselectTabBarItems.swift in Sources */,
 				80ABC18A2574DF7C003D4666 /* MultiselectTrackRow.swift in Sources */,

--- a/MiniVibe/MiniVibe/Models/NowPlaying.swift
+++ b/MiniVibe/MiniVibe/Models/NowPlaying.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 final class NowPlaying: ObservableObject {
     
-    enum Destination {
+    enum Destination: Equatable {
         case albumPlayList(title: String, subtitle: String)
         case artist
         
@@ -26,5 +26,11 @@ final class NowPlaying: ObservableObject {
     @Published var trackId: Int?
     @Published var isPlayerOpen: Bool = false
     @Published var isNavigationActive: Bool = false
-    var destination: Destination?
+    private(set) var destination: Destination?
+    
+    func setDestination(_ destination: Destination) -> Bool {
+        guard self.destination != destination else { return false }
+        self.destination = destination
+        return true
+    }
 }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumPlaylistView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumPlaylistView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct AlbumPlaylistView: View {
-    let title: String // [Album] : 앨범 명, [Playlist] : 플레이리스트 명
-    let subtitle: String // [Album] : 가수 명, [Playlist] : 플레이리스트 명
+    @State private var isOpenMenu = false
+    let title: String
+    let subtitle: String
     
     var body: some View {
         GeometryReader { geometry in
@@ -51,6 +52,9 @@ struct AlbumPlaylistView: View {
                     title: "관련 플레이리스트"
                 )
             }
+            .fullScreenCover(isPresented: $isOpenMenu) {
+                AlbumMenu(title: title, subtitle: subtitle)
+            }
         }
     }
     
@@ -58,15 +62,21 @@ struct AlbumPlaylistView: View {
         HStack(spacing: 10) {
             Button {
                 
-            } label: {  Image(systemName: "heart") }
+            } label: {
+                Image(systemName: "heart")
+            }
             
             Button {
                 
-            } label: {  Image(systemName: "checkmark.circle") }
+            } label: {
+                Image(systemName: "checkmark.circle")
+            }
             
             Button {
-                
-            } label: { Image(systemName: "ellipsis")  }
+                isOpenMenu = true
+            } label: {
+                Image(systemName: "ellipsis")
+            }
         }
         .font(.system(size: 17))
         .foregroundColor(.black)

--- a/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
@@ -18,10 +18,10 @@ struct AlbumMenu: View {
             Spacer()
             MenuThumbnailButton(title: title,
                                 subtitle: subtitle) {
-                nowPlaying.destination = .albumPlayList(title: "Dynamite",
-                                                        subtitle: "방탄소년단")
                 presentationMode.wrappedValue.dismiss()
-                nowPlaying.isNavigationActive = true
+                if nowPlaying.setDestination(.albumPlayList(title: title, subtitle: subtitle)) {
+                    nowPlaying.isNavigationActive = true
+                }
             }
             MenuButton(type: .download(.album))
             MenuButton(type: .like(false))

--- a/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
@@ -1,13 +1,13 @@
 //
-//  PlayerMenu.swift
+//  AlbumMenu.swift
 //  MiniVibe
 //
-//  Created by TTOzzi on 2020/12/01.
+//  Created by TTOzzi on 2020/12/02.
 //
 
 import SwiftUI
 
-struct PlayerMenu: View {
+struct AlbumMenu: View {
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var nowPlaying: NowPlaying
     let title: String
@@ -16,16 +16,15 @@ struct PlayerMenu: View {
     var body: some View {
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton(title: title, subtitle: subtitle) {
-                nowPlaying.destination = .albumPlayList(title: title, subtitle: subtitle)
+            MenuThumbnailButton(title: title,
+                                subtitle: subtitle) {
+                nowPlaying.destination = .albumPlayList(title: "Dynamite",
+                                                        subtitle: "방탄소년단")
                 presentationMode.wrappedValue.dismiss()
-                nowPlaying.isPlayerOpen = false
                 nowPlaying.isNavigationActive = true
             }
-            
-            MenuButton(type: .like(true))
-            MenuButton(type: .exclude)
-            MenuButton(type: .download(.music))
+            MenuButton(type: .download(.album))
+            MenuButton(type: .like(false))
             MenuButton(type: .addToPlaylist)
             MenuButton(type: .share)
             MenuCloseButton {
@@ -35,8 +34,8 @@ struct PlayerMenu: View {
     }
 }
 
-struct PlayerMenu_Previews: PreviewProvider {
+struct AlbumMenu_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerMenu(title: "Among US", subtitle: "정혜일")
+        AlbumMenu(title: "Dynamite", subtitle: "방탄소년단")
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/ArtistMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/ArtistMenu.swift
@@ -22,6 +22,7 @@ struct ArtistMenu: View {
                     .resizable()
                     .aspectRatio(1, contentMode: .fit)
                     .frame(width: 80)
+                    .clipShape(Circle())
                 
                 VStack(alignment: .leading,
                        spacing: 4) {
@@ -45,21 +46,8 @@ struct ArtistMenu: View {
             MenuButton(type: .like(true))
             MenuButton(type: .exclude)
             MenuButton(type: .share)
-            
-            VStack(spacing: 0) {
-                Divider()
-                
-                Button {
-                    presentationMode.wrappedValue.dismiss()
-                } label: {
-                    Spacer()
-                    
-                    Text("닫기")
-                        .foregroundColor(.secondary)
-                        .font(.system(size: 18))
-                    Spacer()
-                }
-                .padding(.vertical)
+            MenuCloseButton {
+                presentationMode.wrappedValue.dismiss()
             }
         }
     }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuButton.swift
@@ -9,9 +9,26 @@ import SwiftUI
 
 struct MenuButton: View {
     enum MenuButtonType: Equatable {
+        enum DownloadType: CustomStringConvertible {
+            case music
+            case album
+            case playlist
+            
+            var description: String {
+                switch self {
+                case .music:
+                    return "곡"
+                case .album:
+                    return "앨범"
+                case .playlist:
+                    return "플레이리스트"
+                }
+            }
+        }
+        
         case like(Bool)
         case exclude
-        case download
+        case download(DownloadType)
         case addToPlaylist
         case share
         
@@ -36,8 +53,8 @@ struct MenuButton: View {
                 return isLike ? "좋아요 취소" : "좋아요"
             case .exclude:
                 return "이 노래 제외"
-            case .download:
-                return "곡 저장"
+            case let .download(type):
+                return "\(type) 저장"
             case .addToPlaylist:
                 return "내 플레이리스트에 추가"
             case .share:

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuCloseButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuCloseButton.swift
@@ -1,0 +1,38 @@
+//
+//  MenuCloseButton.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/12/02.
+//
+
+import SwiftUI
+
+struct MenuCloseButton: View {
+    init(action: @escaping () -> Void) {
+        self.action = action
+    }
+    
+    let action: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            Button {
+                action()
+            } label: {
+                Spacer()
+                Text("닫기")
+                    .foregroundColor(.secondary)
+                    .font(.system(size: 18))
+                Spacer()
+            }
+            .padding(.vertical)
+        }
+    }
+}
+
+struct MenuCloseButton_Previews: PreviewProvider {
+    static var previews: some View {
+        MenuCloseButton(action: { })
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
@@ -1,0 +1,49 @@
+//
+//  MenuThumbnailButton.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/12/02.
+//
+
+import SwiftUI
+
+struct MenuThumbnailButton: View {
+    init(title: String, subtitle: String, action: @escaping () -> Void) {
+        self.title = title
+        self.subtitle = subtitle
+        self.action = action
+    }
+    
+    private let title: String
+    private let subtitle: String
+    private let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Image("playListThumbnail")
+                .resizable()
+                .aspectRatio(1, contentMode: .fit)
+                .frame(width: 80)
+            VStack(alignment: .leading,
+                   spacing: 4) {
+                Text(title)
+                    .font(.system(size: 18, weight: .bold))
+                Text(subtitle)
+                    .foregroundColor(.secondary)
+            }
+            .lineLimit(1)
+            .padding(.horizontal, 8)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .foregroundColor(.secondary)
+        }
+        .foregroundColor(.black)
+        .padding(.horizontal)
+    }
+}
+
+struct MenuThumbnailButton_Previews: PreviewProvider {
+    static var previews: some View {
+        MenuThumbnailButton(title: "Dynamite", subtitle: "방탄소년단", action: { })
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
@@ -17,10 +17,11 @@ struct PlayerMenu: View {
         VStack(spacing: 36) {
             Spacer()
             MenuThumbnailButton(title: title, subtitle: subtitle) {
-                nowPlaying.destination = .albumPlayList(title: title, subtitle: subtitle)
                 presentationMode.wrappedValue.dismiss()
                 nowPlaying.isPlayerOpen = false
-                nowPlaying.isNavigationActive = true
+                if nowPlaying.setDestination(.albumPlayList(title: title, subtitle: subtitle)) {
+                    nowPlaying.isNavigationActive = true
+                }
             }
             
             MenuButton(type: .like(true))

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailSection.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailSection.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ThumbnailSection<Dest: View>: View {
+    @State private var isOpenMenu = false
     let width: CGFloat
     let destination: Dest
     let title: String
@@ -19,10 +20,12 @@ struct ThumbnailSection<Dest: View>: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: width * .spacingRatio) {
                     ForEach(0..<10) { _ in
+                        let title = "요즘 이 곡"
+                        let subtitle = "VIBE"
                         NavigationLink(
-                            destination: AlbumPlaylistView(title: "요즘 이 곡", subtitle: "VIBE"),
+                            destination: AlbumPlaylistView(title: title, subtitle: subtitle),
                             label: {
-                                ThumbnailItem(title: "요즘 이 곡", subtitle: "VIBE")
+                                ThumbnailItem(title: title, subtitle: subtitle)
                                     .frame(width: width * .thumbnailRatio)
                             }
                         )

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerSliderView.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerSliderView.swift
@@ -44,9 +44,10 @@ struct PlayerSliderView: View {
                         .foregroundColor(.secondary)
                 }
                 .onTapGesture {
-                    nowPlaying.destination = .artist
                     nowPlaying.isPlayerOpen = false
-                    nowPlaying.isNavigationActive = true
+                    if nowPlaying.setDestination(.artist) {
+                        nowPlaying.isNavigationActive = true
+                    }
                 }
                 
                 Spacer()


### PR DESCRIPTION
### 📕 Issue Number

Close #142 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 기존 플레이어 메뉴와 아티스트 메뉴의 중복되는 뷰들을 분리
- [x] 만들어진 뷰들을 활용해 앨범 메뉴 화면 구현
- [x] 앨범 메뉴 화면에서 앨범 버튼을 누르면 해당 앨범 화면으로 이동
- [x] 닫기 버튼을 누르면 메뉴 닫기


### 📘 작업 유형

- [x] 신규 기능 추가

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>