### PR TITLE
[iOS] 플레이리스트 화면, 메뉴 화면 구현 #137, #140

### DIFF
--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -45,10 +45,11 @@
 		4478F723256E8B2B00755656 /* PlayAndShuffle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4478F722256E8B2B00755656 /* PlayAndShuffle.swift */; };
 		447BF73B256F3E6C003B5DB7 /* MainTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447BF73A256F3E6C003B5DB7 /* MainTab.swift */; };
 		448FD1CE256F83050027BC57 /* MyMixtape.json in Resources */ = {isa = PBXBuildFile; fileRef = 448FD1CD256F83050027BC57 /* MyMixtape.json */; };
+		44BDF0212578F41900C0A43D /* PlayListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44BDF0202578F41900C0A43D /* PlayListSection.swift */; };
 		44D7B7E725753C2D0049CDBB /* RepeatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E625753C2D0049CDBB /* RepeatButton.swift */; };
 		44D7B7EA25754BF10049CDBB /* PlayerControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E925754BF10049CDBB /* PlayerControls.swift */; };
 		44F97972256CF2AE00C9C224 /* ThumbnailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */; };
-		44F97976256CFBA900C9C224 /* ThumbnailSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97975256CFBA900C9C224 /* ThumbnailSection.swift */; };
+		44F97976256CFBA900C9C224 /* AlbumSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97975256CFBA900C9C224 /* AlbumSection.swift */; };
 		44F9797C256D04EA00C9C224 /* RecommandedPlayListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F9797B256D04EA00C9C224 /* RecommandedPlayListItem.swift */; };
 		44F9797F256D069600C9C224 /* RecommandedPlayListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F9797E256D069600C9C224 /* RecommandedPlayListSection.swift */; };
 		80045DDF25758C5A00F32E6C /* MultiselectTabBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80045DDE25758C5A00F32E6C /* MultiselectTabBarItems.swift */; };
@@ -135,10 +136,11 @@
 		4478F722256E8B2B00755656 /* PlayAndShuffle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAndShuffle.swift; sourceTree = "<group>"; };
 		447BF73A256F3E6C003B5DB7 /* MainTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTab.swift; sourceTree = "<group>"; };
 		448FD1CD256F83050027BC57 /* MyMixtape.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MyMixtape.json; sourceTree = "<group>"; };
+		44BDF0202578F41900C0A43D /* PlayListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayListSection.swift; sourceTree = "<group>"; };
 		44D7B7E625753C2D0049CDBB /* RepeatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatButton.swift; sourceTree = "<group>"; };
 		44D7B7E925754BF10049CDBB /* PlayerControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControls.swift; sourceTree = "<group>"; };
 		44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailItem.swift; sourceTree = "<group>"; };
-		44F97975256CFBA900C9C224 /* ThumbnailSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailSection.swift; sourceTree = "<group>"; };
+		44F97975256CFBA900C9C224 /* AlbumSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumSection.swift; sourceTree = "<group>"; };
 		44F9797B256D04EA00C9C224 /* RecommandedPlayListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommandedPlayListItem.swift; sourceTree = "<group>"; };
 		44F9797E256D069600C9C224 /* RecommandedPlayListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommandedPlayListSection.swift; sourceTree = "<group>"; };
 		4B64F8DD7C3A90466A7DD817 /* Pods-MiniVibe.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiniVibe.debug.xcconfig"; path = "Target Support Files/Pods-MiniVibe/Pods-MiniVibe.debug.xcconfig"; sourceTree = "<group>"; };
@@ -225,7 +227,6 @@
 				8065E4B9257728AF007F5990 /* Menu */,
 				8065E4C72577298C007F5990 /* Components */,
 				8084AB6C256E403900F2AAC2 /* ThumbnailRow.swift */,
-				44F97975256CFBA900C9C224 /* ThumbnailSection.swift */,
 				445919A3256E4A6F0069DAB2 /* ThumbnailGridView.swift */,
 				44139CBA25763C5F000CEEA5 /* ThumbnailGrid.swift */,
 				4478F71B256E858700755656 /* MixtapeGrid.swift */,
@@ -270,6 +271,7 @@
 			isa = PBXGroup;
 			children = (
 				4466D2942578D8E000B65652 /* PlayListView.swift */,
+				44BDF0202578F41900C0A43D /* PlayListSection.swift */,
 			);
 			path = PlayList;
 			sourceTree = "<group>";
@@ -397,6 +399,7 @@
 			isa = PBXGroup;
 			children = (
 				80FA442E25763DE00092D25D /* AlbumView.swift */,
+				44F97975256CFBA900C9C224 /* AlbumSection.swift */,
 			);
 			path = Album;
 			sourceTree = "<group>";
@@ -651,6 +654,7 @@
 				4478F717256E817100755656 /* CGFloat+Constant.swift in Sources */,
 				80045DE225758D1600F32E6C /* MultiselectTabBar.swift in Sources */,
 				80DA95252577A084008C9DFF /* TrackRowC.swift in Sources */,
+				44BDF0212578F41900C0A43D /* PlayListSection.swift in Sources */,
 				4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */,
 				444272B8256CE2B3008BB87B /* PreviewItem.swift in Sources */,
 				444272B3256CDEC8008BB87B /* TodayTitle.swift in Sources */,
@@ -675,7 +679,7 @@
 				4478F720256E89EB00755656 /* ChartList.swift in Sources */,
 				44F9797F256D069600C9C224 /* RecommandedPlayListSection.swift in Sources */,
 				4478F723256E8B2B00755656 /* PlayAndShuffle.swift in Sources */,
-				44F97976256CFBA900C9C224 /* ThumbnailSection.swift in Sources */,
+				44F97976256CFBA900C9C224 /* AlbumSection.swift in Sources */,
 				80FA442F25763DE00092D25D /* AlbumView.swift in Sources */,
 				440D023225779A7F00477A7D /* AlbumMenu.swift in Sources */,
 				80ABC18D2574DFDE003D4666 /* UpNextList.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		447BF73B256F3E6C003B5DB7 /* MainTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447BF73A256F3E6C003B5DB7 /* MainTab.swift */; };
 		448FD1CE256F83050027BC57 /* MyMixtape.json in Resources */ = {isa = PBXBuildFile; fileRef = 448FD1CD256F83050027BC57 /* MyMixtape.json */; };
 		44BDF0212578F41900C0A43D /* PlayListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44BDF0202578F41900C0A43D /* PlayListSection.swift */; };
+		44BDF0252578F72A00C0A43D /* PlayListMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44BDF0242578F72A00C0A43D /* PlayListMenu.swift */; };
 		44D7B7E725753C2D0049CDBB /* RepeatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E625753C2D0049CDBB /* RepeatButton.swift */; };
 		44D7B7EA25754BF10049CDBB /* PlayerControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D7B7E925754BF10049CDBB /* PlayerControls.swift */; };
 		44F97972256CF2AE00C9C224 /* ThumbnailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */; };
@@ -137,6 +138,7 @@
 		447BF73A256F3E6C003B5DB7 /* MainTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTab.swift; sourceTree = "<group>"; };
 		448FD1CD256F83050027BC57 /* MyMixtape.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = MyMixtape.json; sourceTree = "<group>"; };
 		44BDF0202578F41900C0A43D /* PlayListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayListSection.swift; sourceTree = "<group>"; };
+		44BDF0242578F72A00C0A43D /* PlayListMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayListMenu.swift; sourceTree = "<group>"; };
 		44D7B7E625753C2D0049CDBB /* RepeatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepeatButton.swift; sourceTree = "<group>"; };
 		44D7B7E925754BF10049CDBB /* PlayerControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerControls.swift; sourceTree = "<group>"; };
 		44F97971256CF2AE00C9C224 /* ThumbnailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailItem.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 				441EC83F2576031F0069146E /* PlayerMenu.swift */,
 				80045E0D25762C1100F32E6C /* ArtistMenu.swift */,
 				440D023125779A7F00477A7D /* AlbumMenu.swift */,
+				44BDF0242578F72A00C0A43D /* PlayListMenu.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44BDF0252578F72A00C0A43D /* PlayListMenu.swift in Sources */,
 				44D7B7EA25754BF10049CDBB /* PlayerControls.swift in Sources */,
 				80DA952125779FE9008C9DFF /* TrackRowB.swift in Sources */,
 				44139CA325762D7A000CEEA5 /* ArtistItem.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		445919A4256E4A6F0069DAB2 /* ThumbnailGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919A3256E4A6F0069DAB2 /* ThumbnailGridView.swift */; };
 		445919AD256E559D0069DAB2 /* StationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919AC256E559D0069DAB2 /* StationList.swift */; };
 		445919B1256E5CEA0069DAB2 /* StationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445919B0256E5CEA0069DAB2 /* StationStack.swift */; };
+		4466D2952578D8E000B65652 /* PlayListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4466D2942578D8E000B65652 /* PlayListView.swift */; };
 		4474DBFD2574DF78006FC827 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFC2574DF78006FC827 /* Player.swift */; };
 		4474DC002574E2C3006FC827 /* PlayerHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */; };
 		4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */; };
@@ -80,7 +81,7 @@
 		80EB9FE5256D04A000CD99FD /* MagazineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB9FE4256D04A000CD99FD /* MagazineItem.swift */; };
 		80EB9FE8256D0AD700CD99FD /* MagazineSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB9FE7256D0AD700CD99FD /* MagazineSection.swift */; };
 		80EB9FF5256DE8A300CD99FD /* Today.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB9FF4256DE8A300CD99FD /* Today.swift */; };
-		80FA442F25763DE00092D25D /* AlbumPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FA442E25763DE00092D25D /* AlbumPlaylistView.swift */; };
+		80FA442F25763DE00092D25D /* AlbumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FA442E25763DE00092D25D /* AlbumView.swift */; };
 		80FA4433257640330092D25D /* PlaylistAlbumInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FA4432257640330092D25D /* PlaylistAlbumInfo.swift */; };
 		CC104F1456125D58CB9B7320 /* Pods_MiniVibe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF5A04776CA4FAE781C72DD3 /* Pods_MiniVibe.framework */; };
 /* End PBXBuildFile section */
@@ -122,6 +123,7 @@
 		445919A3256E4A6F0069DAB2 /* ThumbnailGridView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailGridView.swift; sourceTree = "<group>"; };
 		445919AC256E559D0069DAB2 /* StationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationList.swift; sourceTree = "<group>"; };
 		445919B0256E5CEA0069DAB2 /* StationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationStack.swift; sourceTree = "<group>"; };
+		4466D2942578D8E000B65652 /* PlayListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayListView.swift; sourceTree = "<group>"; };
 		4474DBFC2574DF78006FC827 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		4474DBFF2574E2C3006FC827 /* PlayerHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerHeader.swift; sourceTree = "<group>"; };
 		4474DC022574E6BC006FC827 /* PlayerThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerThumbnail.swift; sourceTree = "<group>"; };
@@ -174,7 +176,7 @@
 		80EB9FE4256D04A000CD99FD /* MagazineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineItem.swift; sourceTree = "<group>"; };
 		80EB9FE7256D0AD700CD99FD /* MagazineSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineSection.swift; sourceTree = "<group>"; };
 		80EB9FF4256DE8A300CD99FD /* Today.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Today.swift; sourceTree = "<group>"; };
-		80FA442E25763DE00092D25D /* AlbumPlaylistView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlbumPlaylistView.swift; sourceTree = "<group>"; };
+		80FA442E25763DE00092D25D /* AlbumView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlbumView.swift; sourceTree = "<group>"; };
 		80FA4432257640330092D25D /* PlaylistAlbumInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistAlbumInfo.swift; sourceTree = "<group>"; };
 		909FD052C9CC565608492595 /* Pods-MiniVibe.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiniVibe.release.xcconfig"; path = "Target Support Files/Pods-MiniVibe/Pods-MiniVibe.release.xcconfig"; sourceTree = "<group>"; };
 		DF5A04776CA4FAE781C72DD3 /* Pods_MiniVibe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MiniVibe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -262,6 +264,14 @@
 				80045DF9257602A900F32E6C /* Lyrics.swift */,
 			);
 			path = Player;
+			sourceTree = "<group>";
+		};
+		4466D2932578D8CF00B65652 /* PlayList */ = {
+			isa = PBXGroup;
+			children = (
+				4466D2942578D8E000B65652 /* PlayListView.swift */,
+			);
+			path = PlayList;
 			sourceTree = "<group>";
 		};
 		4478F715256E816B00755656 /* Extension */ = {
@@ -353,6 +363,7 @@
 				445E69232575E7B200C7BF21 /* Player */,
 				8065E4B82577289C007F5990 /* Artist */,
 				8065E4C225772949007F5990 /* Album */,
+				4466D2932578D8CF00B65652 /* PlayList */,
 				44141E6F257783FC00A82626 /* Profile */,
 			);
 			path = Views;
@@ -385,7 +396,7 @@
 		8065E4C225772949007F5990 /* Album */ = {
 			isa = PBXGroup;
 			children = (
-				80FA442E25763DE00092D25D /* AlbumPlaylistView.swift */,
+				80FA442E25763DE00092D25D /* AlbumView.swift */,
 			);
 			path = Album;
 			sourceTree = "<group>";
@@ -665,7 +676,7 @@
 				44F9797F256D069600C9C224 /* RecommandedPlayListSection.swift in Sources */,
 				4478F723256E8B2B00755656 /* PlayAndShuffle.swift in Sources */,
 				44F97976256CFBA900C9C224 /* ThumbnailSection.swift in Sources */,
-				80FA442F25763DE00092D25D /* AlbumPlaylistView.swift in Sources */,
+				80FA442F25763DE00092D25D /* AlbumView.swift in Sources */,
 				440D023225779A7F00477A7D /* AlbumMenu.swift in Sources */,
 				80ABC18D2574DFDE003D4666 /* UpNextList.swift in Sources */,
 				8084AB70256E409B00F2AAC2 /* ThumbnailList.swift in Sources */,
@@ -680,6 +691,7 @@
 				44139CA725763283000CEEA5 /* ArtistThumbnail.swift in Sources */,
 				44139C9D25762D17000CEEA5 /* ArtistSection.swift in Sources */,
 				80DA954E25781482008C9DFF /* ChartSectionB.swift in Sources */,
+				4466D2952578D8E000B65652 /* PlayListView.swift in Sources */,
 				447BF73B256F3E6C003B5DB7 /* MainTab.swift in Sources */,
 				44F9797C256D04EA00C9C224 /* RecommandedPlayListItem.swift in Sources */,
 				4474DC062574E8DB006FC827 /* PlayerSlider.swift in Sources */,

--- a/MiniVibe/MiniVibe/Chart.swift
+++ b/MiniVibe/MiniVibe/Chart.swift
@@ -27,7 +27,7 @@ struct Chart: View {
                         ChartSectionB(width: width, sectionTitle: "오늘 TOP 100")
                         ChartSectionB(width: width, sectionTitle: "국내 급상승 🔥")
                         ChartSectionB(width: width, sectionTitle: "VIBE 노래방 TOP 100 🎤")
-                        ThumbnailSection(width: width,
+                        AlbumSection(width: width,
                                          destination: ArtistAlbumGridView(
                                             title: "최신 앨범",
                                             categories: ["국내", "해외"]

--- a/MiniVibe/MiniVibe/Models/NowPlaying.swift
+++ b/MiniVibe/MiniVibe/Models/NowPlaying.swift
@@ -10,13 +10,16 @@ import SwiftUI
 final class NowPlaying: ObservableObject {
     
     enum Destination: Equatable {
-        case albumPlayList(title: String, subtitle: String)
+        case album(title: String, subtitle: String)
+        case playList(title: String, subtitle: String)
         case artist
         
         var view: some View {
             switch self {
-            case let .albumPlayList(title, subtitle):
+            case let .album(title, subtitle):
                 return AnyView(AlbumView(title: title, subtitle: subtitle))
+            case let .playList(title, subtitle):
+                return AnyView(PlayListView(title: title, subtitle: subtitle))
             case .artist:
                 return AnyView(ArtistView())
             }

--- a/MiniVibe/MiniVibe/Models/NowPlaying.swift
+++ b/MiniVibe/MiniVibe/Models/NowPlaying.swift
@@ -16,7 +16,7 @@ final class NowPlaying: ObservableObject {
         var view: some View {
             switch self {
             case let .albumPlayList(title, subtitle):
-                return AnyView(AlbumPlaylistView(title: title, subtitle: subtitle))
+                return AnyView(AlbumView(title: title, subtitle: subtitle))
             case .artist:
                 return AnyView(ArtistView())
             }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
@@ -1,5 +1,5 @@
 //
-//  ThumbnailSection.swift
+//  AlbumSection.swift
 //  MiniVibe
 //
 //  Created by TTOzzi on 2020/11/24.
@@ -7,15 +7,17 @@
 
 import SwiftUI
 
-struct ThumbnailSection<Dest: View>: View {
+struct AlbumSection<D: View>: View {
     @State private var isOpenMenu = false
     let width: CGFloat
-    let destination: Dest
+    let destination: D
     let title: String
     
     var body: some View {
         VStack(spacing: 8) {
-            SectionTitle(width: width, destination: destination, title: title)
+            SectionTitle(width: width,
+                         destination: destination,
+                         title: title)
             
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: width * .spacingRatio) {
@@ -38,9 +40,9 @@ struct ThumbnailSection<Dest: View>: View {
     }
 }
 
-struct ThumbnailSection_Previews: PreviewProvider {
+struct AlbumSection_Previews: PreviewProvider {
     static var previews: some View {
-        ThumbnailSection(width: 375, destination: Text("플레이리스트 목록"), title: "플레이리스트")
+        AlbumSection(width: 375, destination: Text("앨범 목록"), title: "앨범")
             .previewLayout(.fixed(width: 375, height: 300))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -12,7 +12,7 @@ enum ActiveSheet {
     case track
 }
 
-struct AlbumPlaylistView: View {
+struct AlbumView: View {
     @State private var activeSheet: ActiveSheet = .playlist
     @State private var showSheet = false
     
@@ -35,12 +35,13 @@ struct AlbumPlaylistView: View {
                         ) {
                             Section(header: PlayAndShuffle(width: geometry.size.width)) {
                                 ForEach(0..<7) { index in
-                                    TrackRowD(isMenuOpen: $showSheet,
-                                              activeSheet: $activeSheet,
-                                              order: index + 1,
+                                    TrackRowD(order: index + 1,
                                               title: "Dynamite",
                                               artist: "방탄소년단"
-                                    )
+                                    ) {
+                                        activeSheet = .track
+                                        showSheet = true
+                                    }
                                 }
                             }
                             .padding(.horizontal, geometry.size.width * .paddingRatio)
@@ -64,7 +65,6 @@ struct AlbumPlaylistView: View {
                 }
             }
             .padding(.bottom, 70)
-            .navigationTitle("\(title)")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarItems(
                 trailing: trailingBarButtons
@@ -111,7 +111,7 @@ struct AlbumPlaylistView: View {
 struct AlbumPlaylistView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            AlbumPlaylistView(title: "여긴 앨범 이름이야", subtitle: "여긴 가수고")
+            AlbumView(title: "여긴 앨범 이름이야", subtitle: "여긴 가수고")
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -7,15 +7,14 @@
 
 import SwiftUI
 
-enum ActiveSheet {
-    case playlist
-    case track
-}
-
 struct AlbumView: View {
-    @State private var activeSheet: ActiveSheet = .playlist
-    @State private var showSheet = false
+    enum ActiveSheet {
+        case album
+        case track
+    }
     
+    @State private var activeSheet: ActiveSheet = .album
+    @State private var showSheet = false
     let title: String
     let subtitle: String
     
@@ -59,7 +58,9 @@ struct AlbumView: View {
                     
                     PlayListSection(
                         width: width,
-                        title: "관련 플레이리스트"
+                        title: "관련 플레이리스트",
+                        destination: ThumbnailList(title: "관련 플레이리스트",
+                                                   info: .playlist)
                     )
                 }
             }
@@ -69,10 +70,10 @@ struct AlbumView: View {
                 trailing: trailingBarButtons
             )
             .fullScreenCover(isPresented: $showSheet) {
-                if activeSheet == .playlist {
+                if activeSheet == .album {
                     AlbumMenu(title: title, subtitle: subtitle)
                 } else {
-                    PlayerMenu(title: "Among US", subtitle: "정혜일")
+                    PlayerMenu(title: title, subtitle: subtitle)
                 }
             }
         }
@@ -93,13 +94,12 @@ struct AlbumView: View {
             }
             
             Button {
-                activeSheet = .playlist
-                if activeSheet == .playlist {
-                    showSheet = true
-                }
+                activeSheet = .album
+                showSheet = true
             } label: {
                 Image(systemName: "ellipsis")
             }
+            .padding(.vertical)
         }
         .font(.system(size: 17))
         .foregroundColor(.black)

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -48,7 +48,7 @@ struct AlbumView: View {
                         }
                     }
                     
-                    ThumbnailSection(
+                    AlbumSection(
                         width: width,
                         destination: ThumbnailGridView(title: "아티스트의 다른 앨범"),
                         title: "아티스트의 다른 앨범"
@@ -57,9 +57,8 @@ struct AlbumView: View {
                     ArtistSection(width: width,
                                   sectionTitle: "비슷한 아티스트")
                     
-                    ThumbnailSection(
+                    PlayListSection(
                         width: width,
-                        destination: ThumbnailList(title: "관련 플레이리스트", info: .playlist),
                         title: "관련 플레이리스트"
                     )
                 }

--- a/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
@@ -15,7 +15,6 @@ struct ArtistView: View {
             ScrollView {
                 VStack(spacing: 24) {
                     ArtistThumbnail()
-                    //ChartSectionA(width: width, sectionTitle: "노래")
                     
                     VStack {
                         SectionTitle(
@@ -42,7 +41,9 @@ struct ArtistView: View {
                     ArtistSection(width: width,
                                   sectionTitle: "비슷한 아티스트")
                     PlayListSection(width: width,
-                                     title: "관련 플레이리스트")
+                                    title: "관련 플레이리스트",
+                                    destination: ThumbnailList(title: "관련 플레이리스트",
+                                                               info: .playlist))
                 }
             }
             .navigationTitle("방탄소년단")

--- a/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
@@ -33,17 +33,16 @@ struct ArtistView: View {
                         .padding(.horizontal, width * .paddingRatio)   
                     }
                     
-                    ThumbnailSection(width: width,
+                    AlbumSection(width: width,
                                      destination: ArtistAlbumGridView(
                                         title: "앨범",
                                         categories: ["전체", "정규", "비정규", "참여"]
                                      ),
                                      title: "앨범")
-                    ThumbnailSection(width: width,
-                                     destination: ThumbnailList(title: "관련 플레이리스트", info: .playlist),
-                                     title: "관련 플레이리스트")
                     ArtistSection(width: width,
                                   sectionTitle: "비슷한 아티스트")
+                    PlayListSection(width: width,
+                                     title: "관련 플레이리스트")
                 }
             }
             .navigationTitle("방탄소년단")

--- a/MiniVibe/MiniVibe/Views/Common/Components/PlaylistAlbumInfo.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Components/PlaylistAlbumInfo.swift
@@ -13,7 +13,7 @@ struct PlaylistAlbumInfo: View {
     
     var body: some View {
         VStack {
-            EssentialAlbumInfo(title: "여긴 앨범 이름이고", subtitle: "여긴 가수")
+            EssentialAlbumInfo(title: title, subtitle: subtitle)
             OptionalAlbumInfo()
                 .padding(.horizontal, 10)
         }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
@@ -19,7 +19,7 @@ struct AlbumMenu: View {
             MenuThumbnailButton(title: title,
                                 subtitle: subtitle) {
                 presentationMode.wrappedValue.dismiss()
-                if nowPlaying.setDestination(.albumPlayList(title: title, subtitle: subtitle)) {
+                if nowPlaying.setDestination(.album(title: title, subtitle: subtitle)) {
                     nowPlaying.isNavigationActive = true
                 }
             }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuButton.swift
@@ -12,7 +12,7 @@ struct MenuButton: View {
         enum DownloadType: CustomStringConvertible {
             case music
             case album
-            case playlist
+            case playList
             
             var description: String {
                 switch self {
@@ -20,7 +20,7 @@ struct MenuButton: View {
                     return "곡"
                 case .album:
                     return "앨범"
-                case .playlist:
+                case .playList:
                     return "플레이리스트"
                 }
             }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct MenuThumbnailButton: View {
-    init(title: String, subtitle: String, action: @escaping () -> Void) {
+    init(title: String, subtitle: String? = nil, action: @escaping () -> Void) {
         self.title = title
         self.subtitle = subtitle
         self.action = action
     }
     
     private let title: String
-    private let subtitle: String
+    private let subtitle: String?
     private let action: () -> Void
     
     var body: some View {
@@ -28,8 +28,9 @@ struct MenuThumbnailButton: View {
                    spacing: 4) {
                 Text(title)
                     .font(.system(size: 18, weight: .bold))
-                Text(subtitle)
+                Text(subtitle ?? "")
                     .foregroundColor(.secondary)
+                    .opacity(subtitle == nil ? 0 : 1)
             }
             .lineLimit(1)
             .padding(.horizontal, 8)

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayListMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayListMenu.swift
@@ -1,13 +1,13 @@
 //
-//  PlayerMenu.swift
+//  PlayListMenu.swift
 //  MiniVibe
 //
-//  Created by TTOzzi on 2020/12/01.
+//  Created by TTOzzi on 2020/12/03.
 //
 
 import SwiftUI
 
-struct PlayerMenu: View {
+struct PlayListMenu: View {
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var nowPlaying: NowPlaying
     let title: String
@@ -16,17 +16,14 @@ struct PlayerMenu: View {
     var body: some View {
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton(title: title, subtitle: subtitle) {
+            MenuThumbnailButton(title: title) {
                 presentationMode.wrappedValue.dismiss()
-                nowPlaying.isPlayerOpen = false
-                if nowPlaying.setDestination(.album(title: title, subtitle: subtitle)) {
+                if nowPlaying.setDestination(.playList(title: title, subtitle: subtitle)) {
                     nowPlaying.isNavigationActive = true
                 }
             }
-            
-            MenuButton(type: .like(true))
-            MenuButton(type: .exclude)
-            MenuButton(type: .download(.music))
+            MenuButton(type: .download(.playList))
+            MenuButton(type: .like(false))
             MenuButton(type: .addToPlaylist)
             MenuButton(type: .share)
             MenuCloseButton {
@@ -36,8 +33,8 @@ struct PlayerMenu: View {
     }
 }
 
-struct PlayerMenu_Previews: PreviewProvider {
+struct PlayListMenu_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerMenu(title: "Among US", subtitle: "정혜일")
+        PlayListMenu(title: "Dynamite", subtitle: "방탄소년단")
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
@@ -16,7 +16,7 @@ struct ThumbnailGrid: View {
                 ) {
                     ForEach(0..<10) { _ in
                         NavigationLink(
-                            destination: AlbumPlaylistView(title: "요즘 이 곡", subtitle: "VIBE"),
+                            destination: AlbumView(title: "요즘 이 곡", subtitle: "VIBE"),
                             label: {
                                 ThumbnailItem(title: "요즘 이 곡", subtitle: "VIBE")
                             }

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
@@ -42,7 +42,7 @@ struct ThumbnailList: View {
     func destination() -> some View {
         switch info {
         case .playlist:
-            AlbumPlaylistView(title: "EB", subtitle: "방탄소년단")
+            AlbumView(title: "EB", subtitle: "방탄소년단")
         case .magazine:
             Text("Magazine content")
         }

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailSection.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailSection.swift
@@ -23,7 +23,7 @@ struct ThumbnailSection<Dest: View>: View {
                         let title = "요즘 이 곡"
                         let subtitle = "VIBE"
                         NavigationLink(
-                            destination: AlbumPlaylistView(title: title, subtitle: subtitle),
+                            destination: AlbumView(title: title, subtitle: subtitle),
                             label: {
                                 ThumbnailItem(title: title, subtitle: subtitle)
                                     .frame(width: width * .thumbnailRatio)

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
@@ -16,7 +16,7 @@ struct TrackRowA: View {
 
     var body: some View {
         HStack {
-            NavigationLink(destination: AlbumPlaylistView(title: title, subtitle: artist)) {
+            NavigationLink(destination: AlbumView(title: title, subtitle: artist)) {
                 Image("album")
                     .trackRowImageConfigure()
             }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
@@ -13,7 +13,7 @@ struct TrackRowB: View {
 
     var body: some View {
         HStack {
-            NavigationLink(destination: AlbumPlaylistView(title: title, subtitle: artist)) {
+            NavigationLink(destination: AlbumView(title: title, subtitle: artist)) {
                 Image("album")
                     .trackRowImageConfigure()
             }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
@@ -8,14 +8,13 @@
 import SwiftUI
 
 struct TrackRowC: View {
-    @Binding var isMenuOpen: Bool
-    
     let title: String
     let artist: String
+    let menuButtonAction: () -> Void
 
     var body: some View {
         HStack {
-            NavigationLink(destination: AlbumPlaylistView(title: title, subtitle: artist)) {
+            NavigationLink(destination: AlbumView(title: title, subtitle: artist)) {
                 Image("album")
                     .trackRowImageConfigure()
             }
@@ -31,7 +30,7 @@ struct TrackRowC: View {
             Spacer()
             
             Button {
-                isMenuOpen = true
+                menuButtonAction()
             } label: {
                 Image(systemName: "ellipsis")
                     .foregroundColor(.black)
@@ -44,7 +43,7 @@ struct TrackRowC: View {
 
 struct TrackRowC_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowC(isMenuOpen: .constant(false), title: "작은 방 (Feat.아이유)", artist: "스윗소로우")
+        TrackRowC(title: "작은 방 (Feat.아이유)", artist: "스윗소로우", menuButtonAction: { })
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
@@ -8,12 +8,10 @@
 import SwiftUI
 
 struct TrackRowD: View {
-    @Binding var isMenuOpen: Bool
-    @Binding var activeSheet: ActiveSheet
-    
     let order: Int
     let title: String
     let artist: String
+    let menuButtonAction: () -> Void
 
     var body: some View {
         HStack {
@@ -31,10 +29,7 @@ struct TrackRowD: View {
             Spacer()
             
             Button {
-                activeSheet = .track
-                if activeSheet == .track {
-                    isMenuOpen = true
-                }
+                menuButtonAction()
             } label: {
                 Image(systemName: "ellipsis")
                     .foregroundColor(.black)
@@ -47,7 +42,7 @@ struct TrackRowD: View {
 
 struct TrackRowD_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowD(isMenuOpen: .constant(false), activeSheet: .constant(.track), order: 1, title: "작은 방 (Feat.아이유)", artist: "스윗소로우")
+        TrackRowD(order: 1, title: "작은 방 (Feat.아이유)", artist: "스윗소로우", menuButtonAction: { })
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
@@ -14,7 +14,7 @@ struct TrackRowE: View {
 
     var body: some View {
         HStack {
-            NavigationLink(destination: AlbumPlaylistView(title: title, subtitle: artist)) {
+            NavigationLink(destination: AlbumView(title: title, subtitle: artist)) {
                 Image("album")
                     .trackRowImageConfigure()
             }

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
@@ -1,0 +1,48 @@
+//
+//  PlayListSection.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/12/03.
+//
+
+import SwiftUI
+
+struct PlayListSection: View {
+    @State private var isOpenMenu = false
+    let width: CGFloat
+    let title: String
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            SectionTitle(width: width,
+                         destination: ThumbnailList(title: title,
+                                                    info: .playlist),
+                         title: title)
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: width * .spacingRatio) {
+                    ForEach(0..<10) { _ in
+                        let title = "요즘 이 곡"
+                        let subtitle = "VIBE"
+                        NavigationLink(
+                            destination: PlayListView(title: title, subtitle: subtitle),
+                            label: {
+                                ThumbnailItem(title: title, subtitle: subtitle)
+                                    .frame(width: width * .thumbnailRatio)
+                            }
+                        )
+                    }
+                    .foregroundColor(.black)
+                }
+                .padding(.horizontal, width * .paddingRatio)
+            }
+        }
+    }
+}
+
+struct PlayListSection_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayListSection(width: 375, title: "플레이리스트")
+            .previewLayout(.fixed(width: 375, height: 300))
+    }
+}

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
@@ -7,16 +7,16 @@
 
 import SwiftUI
 
-struct PlayListSection: View {
+struct PlayListSection<D: View>: View {
     @State private var isOpenMenu = false
     let width: CGFloat
     let title: String
+    let destination: D
     
     var body: some View {
         VStack(spacing: 8) {
             SectionTitle(width: width,
-                         destination: ThumbnailList(title: title,
-                                                    info: .playlist),
+                         destination: destination,
                          title: title)
             
             ScrollView(.horizontal, showsIndicators: false) {
@@ -42,7 +42,7 @@ struct PlayListSection: View {
 
 struct PlayListSection_Previews: PreviewProvider {
     static var previews: some View {
-        PlayListSection(width: 375, title: "플레이리스트")
+        PlayListSection(width: 375, title: "플레이리스트", destination: Text("플레이리스트 더보기"))
             .previewLayout(.fixed(width: 375, height: 300))
     }
 }

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 
 struct PlayListView: View {
+    enum ActiveSheet {
+        case playList
+        case track
+    }
+    
+    @State private var activeSheet: ActiveSheet = .playList
     @State private var showSheet = false
     let title: String
     let subtitle: String
@@ -31,6 +37,7 @@ struct PlayListView: View {
                                     TrackRowC(title: "Dynamite",
                                               artist: "방탄소년단"
                                     ) {
+                                        activeSheet = .track
                                         showSheet = true
                                     }
                                 }
@@ -49,7 +56,7 @@ struct PlayListView: View {
                 trailing: trailingBarButtons
             )
             .fullScreenCover(isPresented: $showSheet) {
-                PlayerMenu(title: "Among US", subtitle: "정혜일")
+                PlayerMenu(title: title, subtitle: subtitle)
             }
         }
     }
@@ -69,10 +76,12 @@ struct PlayListView: View {
             }
             
             Button {
-                
+                activeSheet = .playList
+                showSheet = true
             } label: {
                 Image(systemName: "ellipsis")
             }
+            .padding(.vertical)
         }
         .font(.system(size: 17))
         .foregroundColor(.black)

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
@@ -1,0 +1,89 @@
+//
+//  PlayListView.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/12/03.
+//
+
+import SwiftUI
+
+struct PlayListView: View {
+    @State private var showSheet = false
+    let title: String
+    let subtitle: String
+    
+    var body: some View {
+        GeometryReader { geometry in
+            let width: CGFloat = geometry.size.width
+            
+            ScrollView {
+                VStack(spacing: 36) {
+                    VStack {
+                        PlaylistAlbumInfo(title: title, subtitle: subtitle)
+                            .padding(.vertical, 10)
+                        
+                        LazyVGrid(
+                            columns: [.init(.fixed(geometry.size.width))],
+                            pinnedViews: [.sectionHeaders]
+                        ) {
+                            Section(header: PlayAndShuffle(width: geometry.size.width)) {
+                                ForEach(0..<20) { _ in
+                                    TrackRowC(title: "Dynamite",
+                                              artist: "방탄소년단"
+                                    ) {
+                                        showSheet = true
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, geometry.size.width * .paddingRatio)
+                        }
+                    }
+                    
+                    ArtistSection(width: width,
+                                  sectionTitle: "참여 아티스트")
+                }
+            }
+            .padding(.bottom, 70)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarItems(
+                trailing: trailingBarButtons
+            )
+            .fullScreenCover(isPresented: $showSheet) {
+                PlayerMenu(title: "Among US", subtitle: "정혜일")
+            }
+        }
+    }
+    
+    var trailingBarButtons: some View {
+        HStack(spacing: 10) {
+            Button {
+                
+            } label: {
+                Image(systemName: "heart")
+            }
+            
+            Button {
+                
+            } label: {
+                Image(systemName: "checkmark.circle")
+            }
+            
+            Button {
+                
+            } label: {
+                Image(systemName: "ellipsis")
+            }
+        }
+        .font(.system(size: 17))
+        .foregroundColor(.black)
+    }
+    
+}
+
+struct PlayListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            PlayListView(title: "요즘이곡", subtitle: "VIBE")
+        }
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
@@ -20,7 +20,7 @@ struct RecommandedPlayListSection: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: width * .spacingRatio) {
                     ForEach(0..<5) { _ in
-                        NavigationLink(destination: AlbumPlaylistView(title: "지붕뚫고 급상승", subtitle: "VIBE")) {
+                        NavigationLink(destination: AlbumView(title: "지붕뚫고 급상승", subtitle: "VIBE")) {
                             RecommandedPlayListItem()
                                 .frame(width: width * .sectionRatio)
                         }

--- a/MiniVibe/MiniVibe/Views/Today/Today.swift
+++ b/MiniVibe/MiniVibe/Views/Today/Today.swift
@@ -34,17 +34,15 @@ struct Today: View {
                             PreviewSection(width: width)
                                 .aspectRatio(1.5, contentMode: .fit)
                             
-                            ThumbnailSection(width: width,
-                                             destination: MixtapeGrid(title: "나를 위한 믹스테잎"),
-                                             title: "나를 위한 믹스테잎")
+                            AlbumSection(width: width,
+                                         destination: MixtapeGrid(title: "나를 위한 믹스테잎"),
+                                         title: "나를 위한 믹스테잎")
                             
-                            ThumbnailSection(width: width,
-                                             destination: ThumbnailList(title: "즐겨듣는 플레이리스트", info: .playlist),
-                                             title: "즐겨듣는 플레이리스트")
+                            PlayListSection(width: width,
+                                         title: "즐겨듣는 플레이리스트")
                             
-                            ThumbnailSection(width: width,
-                                             destination: ThumbnailList(title: "내 취향 플레이리스트", info: .playlist),
-                                             title: "내 취향 플레이리스트")
+                            PlayListSection(width: width,
+                                         title: "내 취향 플레이리스트")
                             
                             StationSection(width: width, title: "DJ 스테이션")
                             
@@ -52,9 +50,9 @@ struct Today: View {
                             
                             RecommandedPlayListSection(width: width, title: "VIBE 추천 플레이리스트")
                             
-                            ThumbnailSection(width: width,
-                                             destination: ThumbnailGridView(title: "좋아할 최신 앨범"),
-                                             title: "좋아할 최신 앨범")
+                            AlbumSection(width: width,
+                                         destination: ThumbnailGridView(title: "좋아할 최신 앨범"),
+                                         title: "좋아할 최신 앨범")
                             
                             MagazineSection(width: width, title: "매거진")
                         }

--- a/MiniVibe/MiniVibe/Views/Today/Today.swift
+++ b/MiniVibe/MiniVibe/Views/Today/Today.swift
@@ -34,15 +34,15 @@ struct Today: View {
                             PreviewSection(width: width)
                                 .aspectRatio(1.5, contentMode: .fit)
                             
-                            AlbumSection(width: width,
-                                         destination: MixtapeGrid(title: "나를 위한 믹스테잎"),
-                                         title: "나를 위한 믹스테잎")
+                            PlayListSection(width: width,
+                                            title: "나를 위한 믹스테잎",
+                                         destination: MixtapeGrid(title: "나를 위한 믹스테잎"))
                             
                             PlayListSection(width: width,
-                                         title: "즐겨듣는 플레이리스트")
+                                            title: "즐겨듣는 플레이리스트", destination: ThumbnailList(title: "즐겨듣는 플레이리스트", info: .playlist))
                             
                             PlayListSection(width: width,
-                                         title: "내 취향 플레이리스트")
+                                            title: "내 취향 플레이리스트", destination: ThumbnailList(title: "내 취향 플레이리스트", info: .playlist))
                             
                             StationSection(width: width, title: "DJ 스테이션")
                             


### PR DESCRIPTION
### 📕 Issue Number

Close #137 
Close #140 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 플레이리스트 화면 구현
- [x] 기존의 AlbumPlayListView를 AlbumView, PlayListView로 나눠서 구현
- [x] TrackRow의 메뉴버튼 액션을 재사용 가능한 방법으로 설정하도록 수정
- [x] 기존 ThumbnailSection으로 합쳐진 뷰를 PlayListSection, AlbumSection으로 분리
- [x] 플레이리스트 메뉴 화면 구현


### 📘 작업 유형

- [x] 신규 기능 추가


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>
