### PR TITLE
[iOS] 탭바 아이콘을 눌러 화면 전환 시 이전에 네비게이션 된 화면이 남아있는 문제 #256

### DIFF
--- a/MiniVibe/MiniVibe/MainTab.swift
+++ b/MiniVibe/MiniVibe/MainTab.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct MainTab: View {
     @State private var contentFrame = CGRect.zero
     @State private var isPlayerPresented = false
-    @State private var tabItemSelection = 0
     @EnvironmentObject private var nowPlaying: NowPlaying
     
     init() {
@@ -19,7 +18,7 @@ struct MainTab: View {
     }
     
     var body: some View {
-        TabView(selection: $tabItemSelection) {
+        TabView(selection: $nowPlaying.tabItemSelection) {
             Today()
                 .tabItem {
                     Image(systemName: "house.fill")

--- a/MiniVibe/MiniVibe/Models/NowPlaying.swift
+++ b/MiniVibe/MiniVibe/Models/NowPlaying.swift
@@ -29,6 +29,11 @@ final class NowPlaying: ObservableObject {
     @Published var trackId: Int?
     @Published var isPlayerOpen = false
     @Published var isNavigationActive = false
+    @Published var tabItemSelection = 0 {
+        didSet {
+            isNavigationActive = false
+        }
+    }
     private(set) var destination: Destination?
     let title = "Dynamite"
     let artist = "방탄소년단"


### PR DESCRIPTION
### 📕 Issue Number

Close #256 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 탭바 아이콘이 눌렸을 때 NowPlaying의 isNavigationActive를 false로 설정해 연결되어있는 뷰들이 pop 되도록 수정

### 📘 작업 유형

- [x] 버그 수정

### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>
