### PR TITLE
[BE] 매거진 개별/ 리스트 조회 API 구현

### DIFF
--- a/server/src/models/Track.ts
+++ b/server/src/models/Track.ts
@@ -23,11 +23,8 @@ class Track {
     @Column()
     title: string;
 
-    @Column()
+    @Column('text')
     lyrics: string;
-
-    @Column('date')
-    releaseDate: Date;
 
     @Column()
     playtime: number;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import newsRouter from './news';
+import magazineRouter from './magazines';
 
 const router = express.Router();
 
 router.use('/news', newsRouter);
+router.use('/magazines', magazineRouter);
 
 export default router;

--- a/server/src/routes/magazines/index.ts
+++ b/server/src/routes/magazines/index.ts
@@ -4,5 +4,6 @@ const magazineController = require('./magazines.controller');
 const router = express.Router();
 
 router.get('/', magazineController.list);
+router.get('/:id', magazineController.findOne);
 
 export default router;

--- a/server/src/routes/magazines/index.ts
+++ b/server/src/routes/magazines/index.ts
@@ -1,0 +1,8 @@
+const express = require('express');
+const magazineController = require('./magazines.controller');
+
+const router = express.Router();
+
+router.get('/', magazineController.list);
+
+export default router;

--- a/server/src/routes/magazines/index.ts
+++ b/server/src/routes/magazines/index.ts
@@ -1,5 +1,5 @@
-const express = require('express');
-const magazineController = require('./magazines.controller');
+import express from 'express';
+import * as magazineController from './magazines.controller';
 
 const router = express.Router();
 

--- a/server/src/routes/magazines/magazines.controller.ts
+++ b/server/src/routes/magazines/magazines.controller.ts
@@ -12,10 +12,43 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
             data: [...magazines],
         });
     } catch (err) {
-        return res.status(500).json({
-            success: false,
-        });
+        return res.status(500).json({ success: false });
     }
 };
 
-export { list };
+const findOne = async (req: Request, res: Response, next: NextFunction) => {
+    const { id } = req.params;
+
+    try {
+        const MagazineRepository = getRepository(Magazine);
+
+        const magazine = await MagazineRepository.createQueryBuilder('magazine')
+            .leftJoinAndSelect('magazine.playlist', 'playlist')
+            .leftJoinAndSelect('playlist.tracks', 'track')
+            .leftJoinAndSelect('track.album', 'album')
+            .leftJoinAndSelect('track.artist', 'artist')
+            .select([
+                'magazine',
+                'playlist.id',
+                'playlist.description',
+                'track',
+                'artist.id',
+                'artist.name',
+                'album.id',
+                'album.title',
+                'album.imageUrl',
+            ])
+            .getOne();
+
+        if (!magazine) return res.status(404).json({ success: false });
+
+        return res.json({
+            success: true,
+            data: magazine,
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
+
+export { list, findOne };

--- a/server/src/routes/magazines/magazines.controller.ts
+++ b/server/src/routes/magazines/magazines.controller.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+
+import Magazine from '../../models/Magazine';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const MagazineRepository = getRepository(Magazine);
+        const magazines = await MagazineRepository.find();
+        return res.json({
+            success: true,
+            data: [...magazines],
+        });
+    } catch (err) {
+        return res.status(500).json({
+            success: false,
+        });
+    }
+};
+
+export { list };

--- a/server/src/routes/magazines/magazines.controller.ts
+++ b/server/src/routes/magazines/magazines.controller.ts
@@ -27,6 +27,7 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
             .leftJoinAndSelect('playlist.tracks', 'track')
             .leftJoinAndSelect('track.album', 'album')
             .leftJoinAndSelect('track.artist', 'artist')
+            .where('magazine.id = :id', { id })
             .select([
                 'magazine',
                 'playlist.id',

--- a/server/src/routes/news/index.ts
+++ b/server/src/routes/news/index.ts
@@ -1,5 +1,5 @@
-const express = require('express');
-const newsController = require('./news.controller');
+import express from 'express';
+import * as newsController from './news.controller';
 
 const router = express.Router();
 


### PR DESCRIPTION
### 📕 Issue Number

Close #282, #283 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 매거진 개별 조회 API 구현
- [x] 매거진 리스트 조회 API 구현


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- API 명세서 수정
     - 기존의 track 객체 안의 albumId, artistId 필드 따로 있었던 부분이 artist/ album 객체 내부의 id를 사용하면 될 것 같아 삭제
     - 매거진 상세 페이지에서 플레이리스트의 description이 쓰여 필드 추가 
```javascript
{
	success, 
	data: { id, 
					imageUrl, 
					title, 
					date,
					category,
					playlists: {
						id,
						description,
					},
					tracks: [ 
										{ id,
											title,
											artist: { id, name },
											album: { id, title, imageUrl }
										}, ...
									]
				}
}
```
- Track에 release date 필드 Album과 중복되어 삭제

<br/><br/>
