### PR TITLE
[BE] 보관함 트랙 관련 API 구현

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import newsRouter from './news';
+import libraryRouter from './library';
 
 const router = express.Router();
 
 router.use('/news', newsRouter);
+router.use('/library', libraryRouter);
 
 export default router;

--- a/server/src/routes/library/index.ts
+++ b/server/src/routes/library/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import trackRouter from './tracks';
+
+const router = express.Router();
+
+router.use('/tracks', trackRouter);
+
+export default router;

--- a/server/src/routes/library/tracks/index.ts
+++ b/server/src/routes/library/tracks/index.ts
@@ -3,6 +3,7 @@ import * as trackController from './library.tracks.controller';
 
 const router = express.Router();
 
+router.get('/', trackController.list);
 router.post('/', trackController.create);
 
 export default router;

--- a/server/src/routes/library/tracks/index.ts
+++ b/server/src/routes/library/tracks/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as trackController from './library.tracks.controller';
+
+const router = express.Router();
+
+router.post('/', trackController.create);
+
+export default router;

--- a/server/src/routes/library/tracks/index.ts
+++ b/server/src/routes/library/tracks/index.ts
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.get('/', trackController.list);
 router.post('/', trackController.create);
+router.delete('/', trackController.remove);
 
 export default router;

--- a/server/src/routes/library/tracks/library.tracks.controller.ts
+++ b/server/src/routes/library/tracks/library.tracks.controller.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+import { getManager } from 'typeorm';
+import User from '../../../models/User';
+import Track from '../../../models/Track';
+
+const create = async (req: Request, res: Response, next: NextFunction) => {
+    const { trackId } = req.body;
+    // TODO: 인증 구현 후 수정
+    const userId = 1;
+
+    const manager = getManager();
+
+    const user = await manager.findOne(User, userId, { relations: ['libraryTracks'] });
+    const track = await manager.findOne(Track, trackId);
+
+    if (!user || !track) return res.status(404).json({ success: false });
+
+    user.libraryTracks.push(track);
+
+    await manager.save(user);
+
+    res.json({
+        success: true,
+    });
+};
+
+export { create };

--- a/server/src/routes/library/tracks/library.tracks.controller.ts
+++ b/server/src/routes/library/tracks/library.tracks.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { getManager } from 'typeorm';
+import { getManager, getRepository } from 'typeorm';
 import User from '../../../models/User';
 import Track from '../../../models/Track';
 
@@ -24,4 +24,33 @@ const create = async (req: Request, res: Response, next: NextFunction) => {
     });
 };
 
-export { create };
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    // TODO: 인증 구현 후 수정
+    const userId = 1;
+
+    const userRepository = getRepository(User);
+    // const libraryTracks = await userRepository.findOne(userId, { relations: ['libraryTracks'] });
+    const libraryTracks = await userRepository.createQueryBuilder('user')
+        .leftJoinAndSelect('user.libraryTracks', 'library_tracks')
+        .leftJoinAndSelect('library_tracks.album', 'album')
+        .leftJoinAndSelect('library_tracks.artist', 'artist')
+        .select([
+            'user.id',
+            'library_tracks.id',
+            'library_tracks.title',
+            'library_tracks.lyrics',
+            'artist.id',
+            'artist.name',
+            'album.id',
+            'album.title',
+            'album.imageUrl',
+        ])
+        .getOne();
+
+    res.json({
+        success: true,
+        data: libraryTracks,
+    });
+};
+
+export { create, list };

--- a/server/src/routes/library/tracks/library.tracks.controller.ts
+++ b/server/src/routes/library/tracks/library.tracks.controller.ts
@@ -30,7 +30,7 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
 
     const userRepository = getRepository(User);
     // const libraryTracks = await userRepository.findOne(userId, { relations: ['libraryTracks'] });
-    const libraryTracks = await userRepository.createQueryBuilder('user')
+    const user = await userRepository.createQueryBuilder('user')
         .leftJoinAndSelect('user.libraryTracks', 'library_tracks')
         .leftJoinAndSelect('library_tracks.album', 'album')
         .leftJoinAndSelect('library_tracks.artist', 'artist')
@@ -46,6 +46,8 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
             'album.imageUrl',
         ])
         .getOne();
+
+    const libraryTracks = user?.libraryTracks ? user?.libraryTracks : [];
 
     res.json({
         success: true,

--- a/server/src/routes/library/tracks/library.tracks.controller.ts
+++ b/server/src/routes/library/tracks/library.tracks.controller.ts
@@ -53,4 +53,24 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
     });
 };
 
-export { create, list };
+const remove = async (req: Request, res: Response, next: NextFunction) => {
+    const trackId: string = req.query.trackId as string;
+    // TODO: 인증 구현 후 수정
+    const userId = 1;
+
+    const manager = getManager();
+
+    const user = await manager.findOne(User, userId, { relations: ['libraryTracks'] });
+
+    if (!user) return res.status(401).json({ success: false });
+
+    user.libraryTracks = user.libraryTracks.filter((libraryTrack) => libraryTrack.id !== +trackId);
+
+    await manager.save(user);
+
+    res.json({
+        success: true,
+    });
+};
+
+export { create, list, remove };


### PR DESCRIPTION
### 📕 Issue Number

Close #285 ,  #287,  #288 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 트랙 보관함 리스트 조회 API 구현
- [x] 트랙 보관함 추가(좋아요) API 구현
- [x] 트랙 보관함 삭제(싫어요) API 구현

### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- userId reqest로 보내지 않도록 명세 수정 
    - 보관함에서 userId request body를 통해 받아오는 걸로 되있는데, 인증 구현할 진 모르겠지만 세션 방식이든 jwt 방식이든 서버쪽에서 userId 알아내도록 할거니 이 부분 삭제할게요 ! 
   - userId 임시로 1번으로 고정

-  post일 때는 body에 trackId 넣어서 요청하는데 delete일 떄는 query 형태로 보내고 있음 -> 한가지 방식으로 통일하는게 좋지 않을까요?

- 구현하면서 명세서대로 하기 어려운 부분 좀 수정하면서 하고 있습니다 .. ㅎㅎ 업데이트되는 명세서 참고 부탁드려요

<br/><br/>
