### PR TITLE
[BE] 아티스트 전체 조회/개별 조회 API 구현  

### DIFF
--- a/server/src/models/Track.ts
+++ b/server/src/models/Track.ts
@@ -37,6 +37,9 @@ class Track {
 
     @ManyToOne((type) => Album, (album) => album.tracks, { nullable: false })
     album: Album;
+
+    @Column()
+    albumId: number;
 }
 
 export default Track;

--- a/server/src/routes/artists/artists.controller.ts
+++ b/server/src/routes/artists/artists.controller.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+
+import Artist from '../../models/Artist';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const ArtistRepository = getRepository(Artist);
+        const artists = await ArtistRepository.find({ relations: ['genre'] });
+        return res.json({
+            success: true,
+            data: [...artists],
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
+
+const findOne = async (req: Request, res: Response, next: NextFunction) => {
+    const { id } = req.params;
+    try {
+        const ArtistRepository = getRepository(Artist);
+        // TODO: 연관된 아티스트 목록 추가
+        const artist = await ArtistRepository.createQueryBuilder('artist')
+            .leftJoinAndSelect('artist.genre', 'genre')
+            .leftJoinAndSelect('artist.tracks', 'track')
+            .leftJoinAndSelect('artist.albums', 'album')
+            .where('artist.id = :id', { id })
+            .select([
+                'artist',
+                'track',
+                'album.id',
+                'album.title',
+                'album.imageUrl',
+            ])
+            .getOne();
+
+        return res.json({
+            success: true,
+            data: artist,
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
+
+export { list, findOne };

--- a/server/src/routes/artists/index.ts
+++ b/server/src/routes/artists/index.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as artistController from './artists.controller';
+
+const router = express.Router();
+
+router.get('/', artistController.list);
+router.get('/:id', artistController.findOne);
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,11 +1,12 @@
 import express from 'express';
+import artistRouter from './artists';
 import newsRouter from './news';
 import magazineRouter from './magazines';
 import libraryRouter from './library';
 
-
 const router = express.Router();
 
+router.use('/artists', artistRouter);
 router.use('/news', newsRouter);
 router.use('/magazines', magazineRouter);
 router.use('/library', libraryRouter);


### PR DESCRIPTION
### 📕 Issue Number

Close #291 , #273 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [ ] 아티스트 전체 조회 API 구현  
- [ ] 아티스트 개별 조회 API 구현  


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아티스트 개별 목록 조회 API  track, album 정보 포함하도록 명세 수정
       - tracks에 album join해서 할까하다가 albums와 데이터가 중복될 것 같아 albumId만 포함하는 것으로 했습니다.
       - 관련 아티스트는 같은 장르의 아티스트 조회하는 형식으로 하면 좋을 듯 ?? -> 추후 추가
```
{
	success, 
	data : {
			id,
			name,
			imageUrl,
			genre : { id, name },
			tracks: [ { id, title, lyrics, playtime, albumId }],
			albums: [ { id, title, imageUrl }]
	}
}
```

<br/><br/>
