### PR TITLE
[BE] 앨범 개별/리스트 조회 API 구현

### DIFF
--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -1,0 +1,59 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+
+import Album from '../../models/Album';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const AlbumRepository = getRepository(Album);
+        const albums = await AlbumRepository.createQueryBuilder('album')
+            .leftJoinAndSelect('album.artist', 'artist')
+            .select(['album', 'artist.id', 'artist.name'])
+            .getMany();
+
+        return res.json({
+            success: true,
+            data: [...albums],
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
+
+// const findOne = async (req: Request, res: Response, next: NextFunction) => {
+//     const { id } = req.params;
+
+//     try {
+//         const MagazineRepository = getRepository(Magazine);
+
+//         const magazine = await MagazineRepository.createQueryBuilder('magazine')
+//             .leftJoinAndSelect('magazine.playlist', 'playlist')
+//             .leftJoinAndSelect('playlist.tracks', 'track')
+//             .leftJoinAndSelect('track.album', 'album')
+//             .leftJoinAndSelect('track.artist', 'artist')
+//             .where('magazine.id = :id', { id })
+//             .select([
+//                 'magazine',
+//                 'playlist.id',
+//                 'playlist.description',
+//                 'track',
+//                 'artist.id',
+//                 'artist.name',
+//                 'album.id',
+//                 'album.title',
+//                 'album.imageUrl',
+//             ])
+//             .getOne();
+
+//         if (!magazine) return res.status(404).json({ success: false });
+
+//         return res.json({
+//             success: true,
+//             data: magazine,
+//         });
+//     } catch (err) {
+//         return res.status(500).json({ success: false });
+//     }
+// };
+
+export { list };

--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -20,40 +20,26 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
     }
 };
 
-// const findOne = async (req: Request, res: Response, next: NextFunction) => {
-//     const { id } = req.params;
+const findOne = async (req: Request, res: Response, next: NextFunction) => {
+    const { id } = req.params;
+    try {
+        const AlbumRepository = getRepository(Album);
+        const album = await AlbumRepository.createQueryBuilder('album')
+            .leftJoinAndSelect('album.artist', 'artist')
+            .leftJoinAndSelect('album.tracks', 'track')
+            .select(['album', 'artist.id', 'artist.name', 'track.id', 'track.title'])
+            .where('album.id = :id', { id })
+            .getOne();
 
-//     try {
-//         const MagazineRepository = getRepository(Magazine);
+        if (!album) return res.status(404).json({ success: false });
 
-//         const magazine = await MagazineRepository.createQueryBuilder('magazine')
-//             .leftJoinAndSelect('magazine.playlist', 'playlist')
-//             .leftJoinAndSelect('playlist.tracks', 'track')
-//             .leftJoinAndSelect('track.album', 'album')
-//             .leftJoinAndSelect('track.artist', 'artist')
-//             .where('magazine.id = :id', { id })
-//             .select([
-//                 'magazine',
-//                 'playlist.id',
-//                 'playlist.description',
-//                 'track',
-//                 'artist.id',
-//                 'artist.name',
-//                 'album.id',
-//                 'album.title',
-//                 'album.imageUrl',
-//             ])
-//             .getOne();
+        return res.json({
+            success: true,
+            data: album,
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
 
-//         if (!magazine) return res.status(404).json({ success: false });
-
-//         return res.json({
-//             success: true,
-//             data: magazine,
-//         });
-//     } catch (err) {
-//         return res.status(500).json({ success: false });
-//     }
-// };
-
-export { list };
+export { list, findOne };

--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -12,8 +12,8 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
             .getMany();
 
         return res.json({
-            success: true,
-            data: [...albums],
+            success: !!albums,
+            data: albums || [],
         });
     } catch (err) {
         return res.status(500).json({ success: false });
@@ -31,11 +31,9 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
             .where('album.id = :id', { id })
             .getOne();
 
-        if (!album) return res.status(404).json({ success: false });
-
         return res.json({
-            success: true,
-            data: album,
+            success: !!album,
+            data: album || {},
         });
     } catch (err) {
         return res.status(500).json({ success: false });

--- a/server/src/routes/albums/index.ts
+++ b/server/src/routes/albums/index.ts
@@ -4,6 +4,6 @@ import * as albumController from './albums.controller';
 const router = express.Router();
 
 router.get('/', albumController.list);
-// router.get('/:id', albumController.findOne);
+router.get('/:id', albumController.findOne);
 
 export default router;

--- a/server/src/routes/albums/index.ts
+++ b/server/src/routes/albums/index.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import * as albumController from './albums.controller';
+
+const router = express.Router();
+
+router.get('/', albumController.list);
+// router.get('/:id', albumController.findOne);
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3,11 +3,14 @@ import newsRouter from './news';
 import magazineRouter from './magazines';
 import libraryRouter from './library';
 
+import albumRouter from './albums';
 
 const router = express.Router();
 
 router.use('/news', newsRouter);
 router.use('/magazines', magazineRouter);
 router.use('/library', libraryRouter);
+
+router.use('/albums', albumRouter);
 
 export default router;


### PR DESCRIPTION
### 📕 Issue Number

Close #305 #306 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 앨범 개별 조회 API 구현
- [x] 앨범 리스트 조회 API 구현


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- PR #301 에서와 비슷한 질문이지만 track에 artist랑 album 정보를 포함하는 것이 중복되더라도 클라이언트 쪽에서 구현하기는 편할까요 ? 고민되네요 .. 
```
{
	success, 
	data: {
			id,
			title,
			artist: { id, name }
			releasedData,
			genre,
			description,
			imageUrl,
			tracks: [ 
								{ id,
									title,
								}, ...
							]
	}
}
```

<br/><br/>
