### PR TITLE
[BE] 플레이리스트 관련 api(2) - 곡 추가/앨범추가/보관함 리스트 조회

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
         indent: ['error', 4],
         'import/prefer-default-export': 'off',
         'no-unused-vars': 'off',
+        'no-console': 'off',
         'import/extensions': [
             'error',
             'ignorePackages',

--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -1,0 +1,13 @@
+{
+    "printWidth": 120,
+    "tabWidth": 4,
+
+    "singleQuote": true,
+    "useTabs": false,
+    "trailingComma": "all",
+
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "semi": true,
+    "endOfLine": "auto"
+}

--- a/server/src/models/Playlist.ts
+++ b/server/src/models/Playlist.ts
@@ -12,6 +12,9 @@ class Playlist {
     @Column()
     title: string;
 
+    @Column()
+    subTitle: string;
+
     @Column({ nullable: true })
     description: string;
 
@@ -20,9 +23,6 @@ class Playlist {
 
     @Column()
     customized: boolean; // true: user가 만든 playlist, false: vibe에서 제공하는 playlist
-
-    @ManyToOne((type) => User, (user) => user.playlists)
-    user: User;
 
     @ManyToMany(() => Track)
     @JoinTable({ name: 'playlist_track' })

--- a/server/src/models/Playlist.ts
+++ b/server/src/models/Playlist.ts
@@ -16,7 +16,7 @@ class Playlist {
     description: string;
 
     @Column()
-    imagerl: string;
+    imageUrl: string;
 
     @Column()
     customized: boolean; // true: user가 만든 playlist, false: vibe에서 제공하는 playlist

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -23,9 +23,6 @@ class User {
     @Column()
     imageUrl: string;
 
-    @OneToMany((type) => Playlist, (playlist) => playlist.user)
-    playlists: Playlist[];
-
     @ManyToMany(() => Track)
     @JoinTable({ name: 'library_tracks' })
     libraryTracks: Track[];

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,12 +2,13 @@ import express from 'express';
 import newsRouter from './news';
 import magazineRouter from './magazines';
 import libraryRouter from './library';
-
+import playlistRouter from './playlists';
 
 const router = express.Router();
 
 router.use('/news', newsRouter);
 router.use('/magazines', magazineRouter);
 router.use('/library', libraryRouter);
+router.use('/playlists', playlistRouter);
 
 export default router;

--- a/server/src/routes/library/index.ts
+++ b/server/src/routes/library/index.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import trackRouter from './tracks';
+import playlistsRouter from './playlists';
 
 const router = express.Router();
 
 router.use('/tracks', trackRouter);
-
+router.use('/playlists', playlistsRouter);
 export default router;

--- a/server/src/routes/library/playlists/index.ts
+++ b/server/src/routes/library/playlists/index.ts
@@ -3,6 +3,6 @@ import * as playlistsController from './library.playlists.controller';
 
 const router = express.Router();
 
+router.get('/', playlistsController.list);
 router.post('/', playlistsController.create);
-
 export default router;

--- a/server/src/routes/library/playlists/index.ts
+++ b/server/src/routes/library/playlists/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as playlistsController from './library.playlists.controller';
+
+const router = express.Router();
+
+router.post('/', playlistsController.create);
+
+export default router;

--- a/server/src/routes/library/playlists/library.playlists.controller.ts
+++ b/server/src/routes/library/playlists/library.playlists.controller.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
-import { getManager } from 'typeorm';
+import { getManager, getRepository } from 'typeorm';
 import Playlist from '../../../models/Playlist';
 import User from '../../../models/User';
 
@@ -23,4 +23,28 @@ const create = async (req: Request, res: Response, next: NextFunction) => {
     }
 };
 
-export { create };
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    const userId = 2;
+
+    try {
+        const UserRepository = getRepository(User);
+        const user = await UserRepository.createQueryBuilder('user')
+            .leftJoinAndSelect('user.libraryPlaylists', 'library_playlists')
+            .select([
+                'user.id',
+                'library_playlists.id',
+                'library_playlists.title',
+                'library_playlists.subTitle',
+                'library_playlists.imageUrl',
+            ])
+            .where('user.id = :id', { id: userId })
+            .getOne();
+
+        const libraryPlaylists = user?.libraryPlaylists || [];
+        return res.json({ success: true, data: libraryPlaylists });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ success: false });
+    }
+};
+export { create, list };

--- a/server/src/routes/library/playlists/library.playlists.controller.ts
+++ b/server/src/routes/library/playlists/library.playlists.controller.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express';
+import { getManager } from 'typeorm';
+import Playlist from '../../../models/Playlist';
+import User from '../../../models/User';
+
+const create = async (req: Request, res: Response, next: NextFunction) => {
+    const { playlistId } = req.body;
+    const userId = 1;
+    try {
+        const manager = getManager();
+        const user = await manager.findOne(User, userId, { relations: ['libraryPlaylists'] });
+        const playlist = await manager.findOne(Playlist, playlistId);
+
+        if (!user || !playlist) return res.status(404).json({ success: false });
+
+        user.libraryPlaylists.push(playlist);
+        await manager.save(user);
+
+        return res.json({ success: true });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ success: false });
+    }
+};
+
+export { create };

--- a/server/src/routes/playlists/index.ts
+++ b/server/src/routes/playlists/index.ts
@@ -4,5 +4,6 @@ import * as playlistsContoller from './playlists.controller';
 const router = express.Router();
 
 router.get('/', playlistsContoller.list);
+router.get('/:id', playlistsContoller.listById);
 
 export default router;

--- a/server/src/routes/playlists/index.ts
+++ b/server/src/routes/playlists/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as playlistsContoller from './playlists.controller';
+
+const router = express.Router();
+
+router.get('/', playlistsContoller.list);
+
+export default router;

--- a/server/src/routes/playlists/index.ts
+++ b/server/src/routes/playlists/index.ts
@@ -7,4 +7,5 @@ router.get('/', playlistsContoller.list);
 router.get('/:id', playlistsContoller.listById);
 router.post('/', playlistsContoller.create);
 router.post('/tracks', playlistsContoller.addTracks);
+router.post('/album', playlistsContoller.addAlbum);
 export default router;

--- a/server/src/routes/playlists/index.ts
+++ b/server/src/routes/playlists/index.ts
@@ -6,4 +6,5 @@ const router = express.Router();
 router.get('/', playlistsContoller.list);
 router.get('/:id', playlistsContoller.listById);
 router.post('/', playlistsContoller.create);
+router.post('/tracks', playlistsContoller.addTracks);
 export default router;

--- a/server/src/routes/playlists/index.ts
+++ b/server/src/routes/playlists/index.ts
@@ -5,5 +5,5 @@ const router = express.Router();
 
 router.get('/', playlistsContoller.list);
 router.get('/:id', playlistsContoller.listById);
-
+router.post('/', playlistsContoller.create);
 export default router;

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -61,6 +61,14 @@ const create = async (req: Request, res: Response, next: NextFunction) => {
 
         playlist.title = title;
         await PlaylistRepository.insert(playlist);
+
+        req.body = {
+            playlistId: playlist.id,
+        };
+        console.log(req.body);
+        await libraryPlaylist.create(req, res, next);
+
+        Error();
     } catch (err) {
         console.error(err);
         return res.status(500).json({ success: false });

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -94,7 +94,7 @@ const addTracks = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const result = await insertTracks(playlistId, tracks);
         if (result) res.json({ success: true });
-        Error();
+        return res.status(500).json({ success: false });
     } catch (err) {
         console.error(err);
         return res.status(500).json({ success: false });
@@ -109,7 +109,7 @@ const addAlbum = async (req: Request, res: Response, next: NextFunction) => {
 
         const result = await insertTracks(playlistId, tracks);
         if (result) return res.json({ success: true });
-        Error();
+        return res.status(500).json({ success: false });
     } catch (err) {
         console.error(err);
         return res.status(500).json({ success: false });

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -15,4 +15,34 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
     }
 };
 
-export { list };
+const listById = async (req: Request, res: Response, next: NextFunction) => {
+    const { id } = req.params;
+    try {
+        const PlaylistRepository = getRepository(Playlist);
+        const playlist = await PlaylistRepository.createQueryBuilder('playlist')
+            .leftJoinAndSelect('playlist.tracks', 'track')
+            .leftJoinAndSelect('track.artist', 'artist')
+            .leftJoinAndSelect('track.album', 'album')
+            .select([
+                'playlist.id',
+                'playlist.title',
+                'playlist.subTitle',
+                'playlist.description',
+                'playlist.imageUrl',
+                'track.id',
+                'track.title',
+                'track.lyrics',
+                'artist.id',
+                'artist.name',
+                'album.id',
+                'album.title',
+                'album.imageUrl',
+            ])
+            .getOne();
+
+        return res.json({ success: true, data: playlist });
+    } catch (err) {
+        console.error(err);
+    }
+};
+export { list, listById };

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { getRepository } from 'typeorm';
+import { getManager, getRepository } from 'typeorm';
 import Playlist from '../../models/Playlist';
 
 const list = async (req: Request, res: Response, next: NextFunction) => {
@@ -43,6 +43,30 @@ const listById = async (req: Request, res: Response, next: NextFunction) => {
         return res.json({ success: true, data: playlist });
     } catch (err) {
         console.error(err);
+        return res.status(500).json({ success: false, data: [] });
     }
 };
-export { list, listById };
+
+const create = async (req: Request, res: Response, next: NextFunction) => {
+    // TODO: userId 처리
+    const { title } = req.body;
+    console.log(title);
+    const userId = 1;
+
+    try {
+        const PlaylistRepository = getRepository(Playlist);
+        await PlaylistRepository.createQueryBuilder('playlist')
+            .insert()
+            .into(Playlist)
+            .values({
+                title,
+            })
+            .execute();
+
+        return res.json({ succee: true });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ success: false });
+    }
+};
+export { list, listById, create };

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { getManager, getRepository } from 'typeorm';
+import * as libraryPlaylist from '../library/playlists/library.playlists.controller';
 import Playlist from '../../models/Playlist';
+import User from '../../models/User';
 
 const list = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -55,18 +57,14 @@ const create = async (req: Request, res: Response, next: NextFunction) => {
 
     try {
         const PlaylistRepository = getRepository(Playlist);
-        await PlaylistRepository.createQueryBuilder('playlist')
-            .insert()
-            .into(Playlist)
-            .values({
-                title,
-            })
-            .execute();
+        const playlist = new Playlist();
 
-        return res.json({ succee: true });
+        playlist.title = title;
+        await PlaylistRepository.insert(playlist);
     } catch (err) {
         console.error(err);
         return res.status(500).json({ success: false });
     }
 };
+
 export { list, listById, create };

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+import Playlist from '../../models/Playlist';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const PlaylistRepository = getRepository(Playlist);
+        const playlists = await PlaylistRepository.find();
+        return res.json({
+            success: true,
+            data: [...playlists],
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false, data: [] });
+    }
+};
+
+export { list };

--- a/server/src/routes/tracks/tracks.controller.ts
+++ b/server/src/routes/tracks/tracks.controller.ts
@@ -62,5 +62,18 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
         });
     }
 };
+const listByAlbumId = async (id:number) : Promise<Track[]> => {
+    try {
+        const TrackRepository = getRepository(Track);
+        const tracks = TrackRepository.createQueryBuilder('track')
+            .select(['track.id'])
+            .where('track.albumId = :id', { id })
+            .getMany();
 
-export { list, findOne };
+        return tracks;
+    } catch (err) {
+        console.error(err);
+        return [];
+    }
+};
+export { list, findOne, listByAlbumId };


### PR DESCRIPTION
### 📕 Issue Number

Close #280 #281 #295 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 플레이리스트에 곡(1개 이상) 추가 구현
- [x] 플레이리스트에 앨범 추가 구현
- [x] 유저 보관함의 플레이리스트 리스트 조회 구현


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 믹스테잎관련
 믹스테잎 관련해서 고민하다가 어떻게 하는 것이 좋을지 몰라 일단 구현을 보류하였습니다...
 문제는 바이브에서 제공하는 믹스테잎이 개인별로 유니크하게 제공되는가(믹스테잎과 유저 1:1) 인것 같습니다.
    - 믹스테잎 조회시 일단 이렇게 생각해 봤습니다.
      1. playlist에 다시 userId 필드를 만들어서 조회시 userId 로 가져오기
      2. 믹스테잎 관련 필드 추가
      3. 그냥 바이브 제공 플레이리스트 중 랜덤으로 가져오기 
    - 믹스테잎이 플레이리스트랑 완전히 같다고도 생각해서 제외하는 것도 생각해봤는데 이벤트 생각하면 있어야 할 것도 같고... 의견부탁드려요

- 특이 사항 2
  한 번에 pr 날리면 너무 커질 거 같아 중간에 브랜치 새로 파서 앞에 거랑 합쳐서 작업했습니다.
  현재 pr 은 merge 이후 commit 만 봐주시면 될 것 같아요 
<br/><br/>
