### PR TITLE
[BE] 믹스테잎 관련 api 구현 및 플레이리스트 관련 api 수정

### DIFF
--- a/server/src/models/Playlist.ts
+++ b/server/src/models/Playlist.ts
@@ -1,7 +1,6 @@
 import {
     Entity, PrimaryGeneratedColumn, Column, ManyToOne, ManyToMany, JoinTable,
 } from 'typeorm';
-import User from './User';
 import Track from './Track';
 
 @Entity()

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -6,6 +6,7 @@ import libraryRouter from './library';
 import playlistRouter from './playlists';
 import albumRouter from './albums';
 import trackRouter from './tracks';
+import mixtapeRouter from './mixtapes';
 
 const router = express.Router();
 
@@ -16,5 +17,5 @@ router.use('/library', libraryRouter);
 router.use('/playlists', playlistRouter);
 router.use('/tracks', trackRouter);
 router.use('/albums', albumRouter);
-
+router.use('/mixtapes', mixtapeRouter);
 export default router;

--- a/server/src/routes/library/index.ts
+++ b/server/src/routes/library/index.ts
@@ -3,7 +3,7 @@ import trackRouter from './tracks';
 import playlistsRouter from './playlists';
 import albumRouter from './album';
 import artistRouter from './artist';
-
+import mixtapeRouter from './mixtapes';
 
 const router = express.Router();
 
@@ -11,5 +11,6 @@ router.use('/tracks', trackRouter);
 router.use('/playlists', playlistsRouter);
 router.use('/album', albumRouter);
 router.use('/artist', artistRouter);
+router.use('/mixtapes', mixtapeRouter);
 
 export default router;

--- a/server/src/routes/library/mixtapes/index.ts
+++ b/server/src/routes/library/mixtapes/index.ts
@@ -1,0 +1,8 @@
+import { log } from 'console';
+import express from 'express';
+import * as mixtapesController from './library.mixtapes.controller';
+
+const router = express.Router();
+
+router.get('/', mixtapesController.list);
+export default router;

--- a/server/src/routes/library/mixtapes/library.mixtapes.controller.ts
+++ b/server/src/routes/library/mixtapes/library.mixtapes.controller.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from 'express';
+import { getRepository } from 'typeorm';
+import User from '../../../models/User';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    const userId = 1;
+
+    try {
+        const UserRepository = getRepository(User);
+        const user = await UserRepository.createQueryBuilder('user')
+            .leftJoinAndSelect('user.libraryPlaylists', 'library_playlists')
+            .select([
+                'user.id',
+                'library_playlists.id',
+                'library_playlists.title',
+                'library_playlists.subTitle',
+                'library_playlists.imageUrl',
+            ])
+            .where('user.id = :id', { id: userId })
+            .where('mixtape = 1')
+            .getOne();
+
+        const libraryPlaylists = user?.libraryPlaylists || [];
+        return res.json({ success: true, data: libraryPlaylists });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ success: false });
+    }
+};
+
+export { list };

--- a/server/src/routes/mixtapes/index.ts
+++ b/server/src/routes/mixtapes/index.ts
@@ -1,0 +1,7 @@
+import express from 'express';
+import * as mixtapesController from './mixtapes.controller';
+
+const router = express.Router();
+
+router.get('/', mixtapesController.list);
+export default router;

--- a/server/src/routes/mixtapes/mixtapes.controller.ts
+++ b/server/src/routes/mixtapes/mixtapes.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+import Playlist from '../../models/Playlist';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const PlaylistRepository = getRepository(Playlist);
+        const mixtapes = await PlaylistRepository.createQueryBuilder('playlist')
+            .select([
+                'playlist.id',
+                'playlist.title',
+                'playlist.subTitle',
+                'playlist.imageUrl',
+            ])
+            .where('mixtape = 1')
+            .getMany();
+
+        return res.json({ success: true, data: mixtapes });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
+
+export { list };

--- a/server/src/routes/playlists/index.ts
+++ b/server/src/routes/playlists/index.ts
@@ -8,4 +8,5 @@ router.get('/:id', playlistsContoller.listById);
 router.post('/', playlistsContoller.create);
 router.post('/tracks', playlistsContoller.addTracks);
 router.post('/album', playlistsContoller.addAlbum);
+router.post('/mylist', playlistsContoller.addPlaylist);
 export default router;

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -1,10 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
-import { EntityManager, getManager, getRepository } from 'typeorm';
-import { isRegExp } from 'util';
+import { getManager, getRepository } from 'typeorm';
 import * as libraryPlaylist from '../library/playlists/library.playlists.controller';
 import * as TrackController from '../tracks/tracks.controller';
 import Playlist from '../../models/Playlist';
-import User from '../../models/User';
 import Track from '../../models/Track';
 
 const list = async (req: Request, res: Response, next: NextFunction) => {

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -88,6 +88,24 @@ const insertTracks = async (playlistId: number, tracks: Track[]) :Promise<boolea
         return false;
     }
 };
+const trackListById = async (id: number) => {
+    try {
+        const PlaylistRepository = getRepository(Playlist);
+        const tracks = await PlaylistRepository.createQueryBuilder('playlist')
+            .leftJoinAndSelect('playlist.tracks', 'track')
+            .select([
+                'playlist.id',
+                'track.id',
+            ])
+            .where('playlist.id = :id', { id })
+            .getOne();
+        if (!tracks) return null;
+        return tracks;
+    } catch (err) {
+        console.error(err);
+        return null;
+    }
+};
 
 const addTracks = async (req: Request, res: Response, next: NextFunction) => {
     const { playlistId, tracks } = req.body;

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -41,6 +41,7 @@ const listById = async (req: Request, res: Response, next: NextFunction) => {
                 'album.title',
                 'album.imageUrl',
             ])
+            .where('playlist.id = :id', { id })
             .getOne();
 
         return res.json({ success: true, data: playlist });

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -88,6 +88,7 @@ const insertTracks = async (playlistId: number, tracks: Track[]) :Promise<boolea
         return false;
     }
 };
+
 const addTracks = async (req: Request, res: Response, next: NextFunction) => {
     const { playlistId, tracks } = req.body;
 
@@ -115,6 +116,23 @@ const addAlbum = async (req: Request, res: Response, next: NextFunction) => {
         return res.status(500).json({ success: false });
     }
 };
+
+const addPlaylist = async (req: Request, res: Response, next: NextFunction) => {
+    const { id, playlistId } = req.body;
+    try {
+        const playlist = await trackListById(playlistId);
+        const tracks = playlist?.tracks || null;
+
+        if (!tracks) return Error();
+
+        const result = await insertTracks(id, tracks);
+        if (result) return res.json({ success: true });
+        return Error();
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ success: false });
+    }
+};
 export {
-    list, listById, create, addTracks, addAlbum,
+    list, listById, create, addTracks, addAlbum, addPlaylist,
 };


### PR DESCRIPTION
### 📕 Issue Number

Close #316 #317 #318 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 믹스테입 리스트 조회 api
- [x] 유저 보관함 - 믹스테입 추가 api
- [x] 특정 플레이리스트에 믹스테잎 추가 api 
- [x] 특정플레이리스트 개별 조회 api 수정 : where 절 빠진 부분 추가


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 개별 믹스테입 조회api 는 개별 플레이리스트 조회 api와 동일하여 구현하지 않았습니다. 
  -> 이 부분은 client 에서 요청 시 개별 플레이리스트 조회로 하면 될 것 같습니다.

- 특정플레이리스트에 믹스테잎을 추가하는 api는 플레이리스트(믹스테입)를 변경하였습니다. 명세서에도 수정해 놓았습니다
 ``` POST api/playlists/mylist```

<br/><br/>
