### PR TITLE
[FE & BE] 데이터 받아오는 방식 변경 & 각 페이지 더미 데이터 변경 & 아티스트 컨트롤러 수정 등

### DIFF
--- a/client/components/molecules/ArtistThumbnail/LibraryArtistThumbnail/LibraryArtistThumbnail.tsx
+++ b/client/components/molecules/ArtistThumbnail/LibraryArtistThumbnail/LibraryArtistThumbnail.tsx
@@ -29,16 +29,21 @@ const ArtistLikeButtonContainer = styled.div`
     z-index: 10;
 `;
 
-const LibraryArtistThumbnail = ({ name, src, href }: LibraryArtistThumbnailProps) => (
-    <Card>
-        <Image variant="regularArtist" src={src} />
-        <ArtistLikeButtonContainer>
-            <ArtistLikeButton />
-        </ArtistLikeButtonContainer>
-        <Link href={href}>
-            <ArtistName>{name}</ArtistName>
-        </Link>
-    </Card>
-);
+const LibraryArtistThumbnail = ( data : LibraryArtistThumbnailProps) => {
+
+    const { id, name, imageUrl } = data;
+
+    return (
+        <Card>
+            <Image variant="regularArtist" src={imageUrl} />
+            <ArtistLikeButtonContainer>
+                <ArtistLikeButton />
+            </ArtistLikeButtonContainer>
+            <Link href="/artist/[id]">
+                <ArtistName>{name}</ArtistName>
+            </Link>
+        </Card>
+    )
+}
 
 export default LibraryArtistThumbnail;

--- a/client/components/molecules/ArtistThumbnail/NormalArtistThumbnail/NormalArtistThumbnail.tsx
+++ b/client/components/molecules/ArtistThumbnail/NormalArtistThumbnail/NormalArtistThumbnail.tsx
@@ -19,11 +19,15 @@ const ArtistName = styled.div`
     font-weight: 400;
 `;
 
-const NormalArtistThumbnail = ({ name, src, href }: NormalArtistThumbnailProps) => (
-    <Card>
-        <Image variant = "regularArtist" src = {src}/>
-        <ArtistName>{name}</ArtistName>
-    </Card>
-  );
+const NormalArtistThumbnail = ( data : NormalArtistThumbnailProps ) => {
+    const { id, name, imageUrl } = data;
+
+    return (
+        <Card>
+            <Image variant = "regularArtist" src = {imageUrl}/>
+            <ArtistName>{name}</ArtistName>
+        </Card>
+      )
+};
   
   export default NormalArtistThumbnail;

--- a/client/components/molecules/ChartCard/ChartCard.styles.tsx
+++ b/client/components/molecules/ChartCard/ChartCard.styles.tsx
@@ -22,6 +22,8 @@ export const Rank = styled.div`
     text-align: center;
 `;
 export const SongInfo = styled.div`
+    display: flex;
+    flex-flow: column;
     padding: 0 20px 0 12px;
     line-height: 21px;
 `;

--- a/client/components/molecules/ChartCard/ChartCard.tsx
+++ b/client/components/molecules/ChartCard/ChartCard.tsx
@@ -3,22 +3,31 @@ import Image from '@components/atoms/Image/Image';
 import Text from '@components/atoms/Text';
 import TrackPlayButton from '@components/molecules/TrackPlayButton';
 import { Card, Rank, SongInfo } from './ChartCard.styles';
+import { ChartCardProps } from 'interfaces/props';
+import A from '@components/atoms/A/A';
 
-const ChartCard = ({ src, rank, artist, trackTitle }) => (
-    <Card>
-        <TrackPlayButton src={src} imgVariant="trackRowCard" />
-        <Rank>
-            <Text variant="k">{rank.toString()}</Text>
-        </Rank>
-        <SongInfo>
-            <a href="#">
-                <Text variant="">{trackTitle}</Text>
-            </a>
-            <a href="#">
-                <Text variant="primary">{artist}</Text>
-            </a>
-        </SongInfo>
-    </Card>
-);
+const ChartCard = ( data : ChartCardProps) => {
+
+    const { id, rank, title, album, artist } = data;
+    const { id: albumId, imageUrl } = album;
+    const { id: artistId, name: artistName } = artist;
+
+    return (
+        <Card>
+            <TrackPlayButton src={imageUrl} imgVariant="trackRowCard" />
+            <Rank>
+                <Text>{rank.toString()}</Text>
+            </Rank>
+            <SongInfo>
+                <A href="/track/[id]">
+                    {title}
+                </A>
+                <A href="/artist/[id]" variant="tertiary">
+                    {artistName}
+                </A>
+            </SongInfo>
+        </Card>
+    )
+}
 
 export default ChartCard;

--- a/client/components/organisms/CardLists/ChartCardList/index.tsx
+++ b/client/components/organisms/CardLists/ChartCardList/index.tsx
@@ -29,7 +29,7 @@ const getCardBundle = (items: ChartCardProps[], unit: number): ChartCardProps[] 
             <ListContainer>
                 {items.slice(i, i + unit).map((item) => (
                     // TODO : 차트카드(노래)의 id key 값으로 설정
-                    <ChartCard {...(item as ChartCardProps)} />
+                    <ChartCard key = { item.id } {...(item as ChartCardProps)} />
                 ))}
             </ListContainer>,
         );

--- a/client/components/organisms/CardLists/ContentsCardList/ContentsCardList.tsx
+++ b/client/components/organisms/CardLists/ContentsCardList/ContentsCardList.tsx
@@ -34,7 +34,7 @@ const properCard = ({variant, items}: ContentsCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <MixtapeCard {...(item as MixtapeCardProps)} />
+                        <MixtapeCard key = {item.id} {...(item as MixtapeCardProps)} />
                     </Item>
                 ))
             )
@@ -42,7 +42,7 @@ const properCard = ({variant, items}: ContentsCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <NormalArtistThumbnail {...(item as LibraryArtistThumbnailProps)} />
+                        <NormalArtistThumbnail key = {item.id} {...(item as LibraryArtistThumbnailProps)} />
                     </Item>
                 ))
             )
@@ -50,7 +50,7 @@ const properCard = ({variant, items}: ContentsCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <AlbumCard {...(item as AlbumCardProps)} />
+                        <AlbumCard key = {item.id} {...(item as AlbumCardProps)} />
                     </Item>
                 ))
             )
@@ -58,7 +58,7 @@ const properCard = ({variant, items}: ContentsCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <PlaylistCard {...(item as PlaylistCardProps)} />
+                        <PlaylistCard key = {item.id} {...(item as PlaylistCardProps)} />
                     </Item>
                 ))
             )
@@ -66,7 +66,7 @@ const properCard = ({variant, items}: ContentsCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <NewsCard {...item} />
+                        <NewsCard key = {item.id} {...item} />
                     </Item>
                 ))
             )

--- a/client/components/organisms/CardLists/TrackRowList/TrackRowList.stories.tsx
+++ b/client/components/organisms/CardLists/TrackRowList/TrackRowList.stories.tsx
@@ -5,118 +5,25 @@ export default {
     title: 'Organisms/TrackRowList',
     component: TrackRowList,
 };
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg?type=r360Fll&v=20200507115931',
-    trackId: '1',
-    trackTitle: '그냥',
-    artist: '이영지',
-    albumTitle: '그냥',
-    lyrics: `keep callin' to me
-    왜 인지는 묻지 말아 주면은 안돼?
-    just text me 
-    밥은 잘 먹고 있는지에 대해
-    뭔들 난 다 좋아
-    별거 없는 그런 삶
-    im so sick of these days
-    말해 줘 너의 밤은 어때
-    또 너의 날은 어떻고?
-    나의 시간은 못 돼서
-    다시 이 굴레에 날 가둬  
-    이 밤은 또 내껄
-    자꾸만 뺏으려 들어
-    where should i go right now? 
-    
-    뭘 쥐어도 다 모래
-    결국 흐르니 난 뭘 해?  
-    못 된 생각이 인내를 놓을땐 
-    도태 되는거야 no thanks
-    가지면 뭐해
-    i got nothing to prove no
-    사랑을 할래
-    위기는 모르는 채로 oh 
-    너 불안정한 내게
-    자꾸 깊은 믿음을 심어주지마
-    나도 모르는 새에
-    널 내 안에 들여놓고 착각 할지도 몰라
-    
-    painful thoughts 
-    in ma head 
-    다 모순인 거야
-    비운의 틈새로
-    나 겨울의 냄새를 맡고파
-    painful thoughts
-    im ma head 
-    다 거짓인 거야
-    난 그저 여름의 향수에만 잠깐 젖고파
-    cuz im bored
-    아늑하기만 한
-    나의 방은 어두워서
-    상처는 아물지  않아
-    날 봐줘
-    저 멀리 가고 있는
-    날 보게 된다면은 붙잡아줘 
-    
-    time is tickin' when the love is begin
-    i can take you everywhere 
-    왜 망설이고 있어?
-    time is tickin' when the love is begin--
-    나와/ 밤을 새 아침이 없는 것처럼
-    time is tickin' when the love is begin
-    maybe we can find out/ the answer
-    time is tickin' when the love is begin  
-    oh 얘기를 해 잠은 충분해 난     
-    
-    잠은 충분해 매일
-    다 버려진 채 잠식당할까 그게 두려워 
-    넌, 넌 나를 찾고 있어?
-    내가 성급해 보이더라도 나를 꼭 안아줘
-    배고픈 내일이 와도
-    고대하던 것들이 다 무너져도
-    it doesn't matter anymore 
-    그냥 공허할 뿐인 거야
-    내가 쥐었던 게 다
-    스치듯 지나가니까
-    
-    난 아둔한 poor little girl  
-    나와 같이 가자 차피 재미를 볼 거는 너
-    닮았다니까 우린 
-    그렇게 굴지 마
-    난 괜히 다 포용을 하는 stupid uh uh
-    dumbass 너는 뭔데?
-    됐고 머릴 머릴 비워
-    나는 못 됐어
-    뻔해 우리의 결말
-    근데 난 아직도 답답해 왠지
-    
-    painful thoughts 
-    in ma head 
-    다 모순인 거야
-    비운의 틈새로
-    나 겨울의 냄새를 맡고파
-    painful thoughts 
-    im ma head 
-    다 거짓인 거야
-    난 그저 여름의 향수에만 잠깐 젖고파
-    cuz im boared
-    아늑하기만 한
-    나의 방은 어두워서 
-    상처는 아물지 않아
-    날 봐줘
-    저 멀리 가고 있는
-    날 보게 된다면은 붙잡아줘 
-    
-    time is tickin' when the love is begin
-    i can take you everywhere 
-    왜 망설이고 있어?
-    time is tickin' when the love is begin
-    나와 밤을 새 아침이 없는 것처럼
-    time is tickin' when the love is begin
-    maybe we can find out the answer
-    time is tickin' when the love is begin  
-    oh 얘기를 해 잠은 충분해 난  
-    
-    we can find out the answer
-    we can find out the answer
-    `
-});
+
+const data = {
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 1
+}
+
+const TrackDatas = Array(20).fill(data);
+
 export const Default = () => <TrackRowList items={TrackDatas} />;

--- a/client/components/organisms/CardLists/TrackRowList/index.tsx
+++ b/client/components/organisms/CardLists/TrackRowList/index.tsx
@@ -11,7 +11,7 @@ const ListContainer = styled.ul`
 const TrackRowList = ({ items }: { items: TrackRowCardProps[] }) => (
     <ListContainer>
         {items.map((item) => (
-            <TrackRowCard {...(item as TrackRowCardProps)} />
+            <TrackRowCard key= {item.id} {...(item as TrackRowCardProps)} />
         ))}
     </ListContainer>
 );

--- a/client/components/organisms/Cards/AlbumCard/AlbumCard.tsx
+++ b/client/components/organisms/Cards/AlbumCard/AlbumCard.tsx
@@ -34,20 +34,25 @@ const StyledA = styled(A)`
     font-size: 16px;
 `;
 
-const AlbumCard = ({ title, artist, src, href }: AlbumCardProps) => (
-    <CardContainer>
-        <ThumbnailContainer>
-            <ContentsThumbnail src={src} href={href} sort="" />
-        </ThumbnailContainer>
-        <TextContainer>
-            <TitelContainer>
-                <StyledA href={href}>{title}</StyledA>
-            </TitelContainer>
-            <DescriptionContainer>
-                <Text variant="primary">{artist}</Text>
-            </DescriptionContainer>
-        </TextContainer>
-    </CardContainer>
-);
+const AlbumCard = ( data : AlbumCardProps) => {
+    const { id, title, description, releaseDate, imageUrl, artist } = data;
+    const { id: artistId, name: artistName } = artist;
+
+    return (
+        <CardContainer>
+            <ThumbnailContainer>
+                <ContentsThumbnail src={imageUrl} href="album/[id]" sort="" />
+            </ThumbnailContainer>
+            <TextContainer>
+                <TitelContainer>
+                    <StyledA href="album/[id]">{title}</StyledA>
+                </TitelContainer>
+                <DescriptionContainer>
+                    <Text variant="primary">{artistName}</Text>
+                </DescriptionContainer>
+            </TextContainer>
+        </CardContainer>
+    )
+};
 
 export default AlbumCard;

--- a/client/components/organisms/Cards/MagazineCard/MagazineCard.tsx
+++ b/client/components/organisms/Cards/MagazineCard/MagazineCard.tsx
@@ -33,20 +33,23 @@ const StyledA = styled(A)`
     font-size: 16px;
 `;
 
-const MagazineCard = ({ title, date, src, href, sort }: MagazineCardProps) => (
-    <CardContainer sort={sort}>
+const MagazineCard = ( data : MagazineCardProps ) => {
+    const { id, title, imageUrl, date, category } = data;
+
+    return(
+    <CardContainer>
         <ThumbnailContainer>
-            <ContentsThumbnail src={src} href={href} sort={sort} />
+            <ContentsThumbnail src={imageUrl} href="magazine/[id]" sort='todayMagazine' />
         </ThumbnailContainer>
         <TextContainer>
             <TitelContainer>
-                <StyledA href={href}>{title}</StyledA>
+                <StyledA href="magazine/[id]">{title}</StyledA>
             </TitelContainer>
             <DescriptionContainer>
                 <Text variant="primary">{date}</Text>
             </DescriptionContainer>
         </TextContainer>
     </CardContainer>
-);
+)};
 
 export default MagazineCard;

--- a/client/components/organisms/Cards/MainMagazineCard/MainMagazineCard.tsx
+++ b/client/components/organisms/Cards/MainMagazineCard/MainMagazineCard.tsx
@@ -42,34 +42,38 @@ const DescriptionContainer = styled.div`
 `;
 
 interface MainMagazineCardProps {
-    src: string;
-    href: string;
-    title: string;
-    label: string;
-    description: string;
+    id: number,
+    imageUrl: string,
+    title: string,
+    description: string,
+    date: string,
+    category: string
 }
 
-const MainMagazineCard = ({ title, src, href, description, label }: MainMagazineCardProps) => (
-    <CardContainer>
-        <ImageContainer>
-            <Image variant="primary" src={src} />
-        </ImageContainer>
-        <ContentsContainer>
-            <LabelContainer>
-                <Label selected={true} variant="secondary">
-                    {label}
-                </Label>
-            </LabelContainer>
-            <TitleContainer>
-                <A variant="primary" href={href}>
-                    {title}
-                </A>
-            </TitleContainer>
-            <DescriptionContainer>
-                <Text variant="primary">{description}</Text>
-            </DescriptionContainer>
-        </ContentsContainer>
-    </CardContainer>
-);
+const MainMagazineCard = ( data : MainMagazineCardProps) => {
+    const {id, imageUrl, title, description, date, category } = data;
+    return (
+        <CardContainer>
+            <ImageContainer>
+                <Image variant="primary" src={imageUrl} />
+            </ImageContainer>
+            <ContentsContainer>
+                <LabelContainer>
+                    <Label selected={true} variant="secondary">
+                        {category}
+                    </Label>
+                </LabelContainer>
+                <TitleContainer>
+                    <A variant="primary" href="magazine/[id]">
+                        {title}
+                    </A>
+                </TitleContainer>
+                <DescriptionContainer>
+                    <Text variant="primary">{description}</Text>
+                </DescriptionContainer>
+            </ContentsContainer>
+        </CardContainer>
+    )
+};
 
 export default MainMagazineCard;

--- a/client/components/organisms/Cards/MixtapeCard/MixtapeCard.tsx
+++ b/client/components/organisms/Cards/MixtapeCard/MixtapeCard.tsx
@@ -39,20 +39,24 @@ const StyledText = styled(Text)`
     font-size: 13px;
 `;
 
-const MixtapeCard = ({ title, artist, src, href }: MixtapeCardProps) => (
-    <CardContainer>
-        <ThumbnailContainer>
-            <ContentsThumbnail src={src} href={href} sort="" />
-        </ThumbnailContainer>
-        <TextContainer>
-            <TitelContainer>
-                <StyledA href={href}>{title}</StyledA>
-            </TitelContainer>
-            <DescriptionContainer>
-                <StyledText variant="primary">{artist}</StyledText>
-            </DescriptionContainer>
-        </TextContainer>
-    </CardContainer>
-);
+const MixtapeCard = ( data : MixtapeCardProps) => {
+
+    const { id, title, subtitle, description, imageUrl, customized } = data;
+
+    return (
+        <CardContainer>
+            <ThumbnailContainer>
+                <ContentsThumbnail src={imageUrl} href="/mixtape/[id]" sort="" />
+            </ThumbnailContainer>
+            <TextContainer>
+                <TitelContainer>
+                    <StyledA href="/mixtape/[id]">{title}</StyledA>
+                </TitelContainer>
+                <DescriptionContainer>
+                    <StyledText variant="primary">{description}</StyledText>
+                </DescriptionContainer>
+            </TextContainer>
+        </CardContainer>
+    )};
 
 export default MixtapeCard;

--- a/client/components/organisms/Cards/NewsCard/NewsCard.tsx
+++ b/client/components/organisms/Cards/NewsCard/NewsCard.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import ContentsThumbnail from '@components/molecules/ContentsThumbnail/ContentsThumbnail';
 import A from '@components/atoms/A/A';
 import Text from '@components/atoms/Text';
+import NewsCardProps from '@interface/props';
 
 const CardContainer = styled.div`
     display: flex;
@@ -18,7 +19,7 @@ const TextContainer = styled.div`
     flex-flow: column;
 `;
 
-const TitelContainer = styled.div`
+const TitleContainer = styled.div`
     padding: 10px 0px 10px 0px;
 `;
 
@@ -30,29 +31,25 @@ const StyledA = styled(A)`
     font-size: 16px;
 `;
 
-interface NewsCardProps {
-    src: string;
-    href: string;
-    newsHref: string;
-    title: string;
-}
-
-const NewsCard = ({ title, src, href, newsHref }: NewsCardProps) => (
-    <CardContainer>
-        <ThumbnailContainer>
-            <ContentsThumbnail sort="news" src={src} href={href} />
-        </ThumbnailContainer>
-        <TextContainer>
-            <TitelContainer>
-                <StyledA href={href}>{title}</StyledA>
-            </TitelContainer>
-            <DescriptionContainer>
-                <A href={newsHref} variant="tertiary">
-                    관련 뉴스 보기
-                </A>
-            </DescriptionContainer>
-        </TextContainer>
-    </CardContainer>
-);
+const NewsCard = ( data : NewsCardProps) => {
+    const {id, title, imageUrl, date, link, albumId} = data;
+    return (
+        <CardContainer>
+            <ThumbnailContainer>
+                <ContentsThumbnail sort="news" src={imageUrl} href="/album/[id]" />
+            </ThumbnailContainer>
+            <TextContainer>
+                <TitleContainer>
+                    <StyledA href="/album/[id]">{title}</StyledA>
+                </TitleContainer>
+                <DescriptionContainer>
+                    <A href={link} variant="tertiary">
+                        관련 뉴스 보기
+                    </A>
+                </DescriptionContainer>
+            </TextContainer>
+        </CardContainer>
+    )
+};
 
 export default NewsCard;

--- a/client/components/organisms/Cards/PlaylistCard/PlaylistCard.tsx
+++ b/client/components/organisms/Cards/PlaylistCard/PlaylistCard.tsx
@@ -35,20 +35,25 @@ const StyledA = styled(A)`
     font-size: 16px;
 `;
 
-const PlaylistCard = ({ title, description, src, href }: PlaylistCardProps) => (
-    <CardContainer>
-        <ThumbnailContainer>
-            <ContentsThumbnail src={src} href={href} sort="" />
-        </ThumbnailContainer>
-        <TextContainer>
-            <TitelContainer>
-                <StyledA href={href}>{title}</StyledA>
-            </TitelContainer>
-            <DescriptionContainer>
-                <Text variant="primary">{description}</Text>
-            </DescriptionContainer>
-        </TextContainer>
-    </CardContainer>
-);
+const PlaylistCard = ( data : PlaylistCardProps) => {
+
+    const { id, title, subtitle, description, imageUrl, customized } = data;
+
+    return (
+        <CardContainer>
+            <ThumbnailContainer>
+                <ContentsThumbnail src={imageUrl} href="/playlist/[id]" sort="" />
+            </ThumbnailContainer>
+            <TextContainer>
+                <TitelContainer>
+                    <StyledA href="/playlist/[id]">{title}</StyledA>
+                </TitelContainer>
+                <DescriptionContainer>
+                    <Text variant="primary">{description}</Text>
+                </DescriptionContainer>
+            </TextContainer>
+        </CardContainer>
+    )
+};
 
 export default PlaylistCard;

--- a/client/components/organisms/Cards/TrackRowCard/TrackRowCard.stories.tsx
+++ b/client/components/organisms/Cards/TrackRowCard/TrackRowCard.stories.tsx
@@ -12,4 +12,23 @@ const TrackRowCardData = {
     artist: '미란이',
     albumTitle: '쇼미더머니 9 Episode 1',
 };
-export const Default = () => <TrackRowCard {...TrackRowCardData} />;
+
+const data = {
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 1
+}
+
+export const Default = () => <TrackRowCard {...data} />;

--- a/client/components/organisms/Cards/TrackRowCard/index.tsx
+++ b/client/components/organisms/Cards/TrackRowCard/index.tsx
@@ -7,6 +7,7 @@ import TrackPlayButton from '@components/molecules/TrackPlayButton';
 import DropDownMenu from '@components/molecules/DropdownMenu';
 import { TrackRowCardProps } from '@interfaces/props';
 import LyricModal from '@components/organisms/LyricModal/LyricModal';
+import QueueMusicIcon from '@material-ui/icons/QueueMusic';
 
 import {
     List,
@@ -34,8 +35,13 @@ const contentsDropDownMenu = [{
     content: '가사 보기'
 }]
 
-const TrackRowCard = ({ trackId, albumImgSrc, trackTitle, artist, albumTitle, href, lyrics }: TrackRowCardProps) => {
-    const [isLiked, setIsLiked] = useState(true);
+const TrackRowCard = ( data : TrackRowCardProps ) => {
+    
+    const { id, title, lyrics, album, artist, liked } = data;
+    const { id: albumId, title: albumTitle, imageUrl} = album;
+    const { id: artistId, name: artistName } = artist;
+
+    const [isLiked, setIsLiked] = useState(liked);
     const [displayLyrics, setDisplayLyrics] = useState(false);
 
     const onClickUnlikeHandler = () => {
@@ -48,24 +54,24 @@ const TrackRowCard = ({ trackId, albumImgSrc, trackTitle, artist, albumTitle, hr
 
     return (
     <List>
-        <LyricModal src={albumImgSrc} title={trackTitle} artist={artist} lyrics={lyrics} visibility = {displayLyrics} onClickFunc = {onClickShowLyric}/>
+        <LyricModal src={imageUrl} title={albumTitle} artist={artistName} lyrics={lyrics} visibility = {displayLyrics} onClickFunc = {onClickShowLyric}/>
         <TrackLeft>
-            <CheckBox id={trackId} />
+            <CheckBox id={id} />
             <TrackPlayBtnContainer>
-                <TrackPlayButton src={albumImgSrc} imgVariant="trackRowCard" />
+                <TrackPlayButton src={imageUrl} imgVariant="trackRowCard" />
             </TrackPlayBtnContainer>
             <TrackTitle>
-                <A href={href}>{trackTitle}</A>
+                <A href="/track/[id]">{title}</A>
             </TrackTitle>
         </TrackLeft>
         <TrackMiddle>
             <TrackMiddleElem>
-                <A href="#" variant="tertiary">
-                    {artist}
+                <A href="/artist/[id]" variant="tertiary">
+                    {artistName}
                 </A>
             </TrackMiddleElem>
             <TrackMiddleElem>
-                <A href="#" variant="tertiary">
+                <A href="/album/[id]" variant="tertiary">
                     {albumTitle}
                 </A>
             </TrackMiddleElem>
@@ -77,13 +83,11 @@ const TrackRowCard = ({ trackId, albumImgSrc, trackTitle, artist, albumTitle, hr
                 </A>
             </Mp3>
             <ShowLyricButton onClick = { onClickShowLyric }>
-                <A href="#">
-                    <HiddenText>가사보기</HiddenText>
-                </A>
+                <QueueMusicIcon style={{ color: '#999' }}/>
             </ShowLyricButton>
             <Like>
-                {isLiked && <FavoriteIcon style={{ color: '#FF1150' }} fontSize = "small" onClick = {onClickUnlikeHandler}/>}
-                {!isLiked && <DropDownMenu
+                {(isLiked == 1) && <FavoriteIcon style={{ color: '#FF1150' }} fontSize = "small" onClick = {onClickUnlikeHandler}/>}
+                {(isLiked == 0) && <DropDownMenu
                     id = "contents" 
                     control = {StyledMoreHorizIcon} 
                     menuItems = {contentsDropDownMenu}/>}

--- a/client/components/organisms/DetailHeader/index.tsx
+++ b/client/components/organisms/DetailHeader/index.tsx
@@ -59,22 +59,22 @@ const DescriptionContainer = styled.div`
 `;
 
 interface DetailHeaderProps {
-    sort: 'album' | 'mixtape' | 'playlist' | 'track';
-    data: JSON;
+    sort: 'album' | 'mixtape' | 'playlist' | 'track',
+    data
 }
 
 const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
     return (
         <HeaderContainter>
             <ImageContainer>
-                <Image src={data.src} variant="" />
+                <Image src={sort === "album" || "mixtape" ? data.imageUrl : data.album.imageUrl} variant="" />
             </ImageContainer>
             <DetailContainer>
                 <TextContainer>
                     <TitleContainer>
                         <Text variant="tertiary">{data.title}</Text>
                     </TitleContainer>
-                    {sort === 'album' || 'track' ? <ArtistContainer>{data.artist}</ArtistContainer> : ''}
+                    {sort === 'album' || 'track' ? <ArtistContainer>{data.artist?.name}</ArtistContainer> : ''}
                     {sort === 'album' && (
                         <DateGenreContainer>
                             <Text variant="primary">
@@ -83,7 +83,7 @@ const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
                         </DateGenreContainer>
                     )}
                     <DescriptionContainer>
-                        <Text variant="primary">{sort === 'mixtape' ? data.artist : data.description}</Text>
+                        <Text variant="primary">{data.description}</Text>
                     </DescriptionContainer>
                 </TextContainer>
                 <ButtonContainer>

--- a/client/components/organisms/Library/LibraryCardList/LibraryCardList.tsx
+++ b/client/components/organisms/Library/LibraryCardList/LibraryCardList.tsx
@@ -19,7 +19,7 @@ const properCard = ({variant, items}: LibraryCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <MixtapeCard {...(item as MixtapeCardProps)} />
+                        <MixtapeCard key = { item.id } {...(item as MixtapeCardProps)} />
                     </Item>
                 ))
             )
@@ -27,7 +27,7 @@ const properCard = ({variant, items}: LibraryCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <LibraryArtistThumbnail {...(item as LibraryArtistThumbnailProps)} />
+                        <LibraryArtistThumbnail key = { item.id } {...(item as LibraryArtistThumbnailProps)} />
                     </Item>
                 ))
             )
@@ -35,7 +35,7 @@ const properCard = ({variant, items}: LibraryCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <AlbumCard {...(item as AlbumCardProps)} />
+                        <AlbumCard key = { item.id } {...(item as AlbumCardProps)} />
                     </Item>
                 ))
             )
@@ -43,7 +43,7 @@ const properCard = ({variant, items}: LibraryCardListProps) => {
             return (
                 items.map((item) => (
                     <Item>
-                        <PlaylistCard {...(item as PlaylistCardProps)} />
+                        <PlaylistCard key = { item.id } {...(item as PlaylistCardProps)} />
                     </Item>
                 ))
             )

--- a/client/interfaces/props.ts
+++ b/client/interfaces/props.ts
@@ -4,81 +4,111 @@ export enum MagazineSort {
 }
 
 export interface MagazineCardProps {
-    src: string,
-    href: string,
+    id: number,
     title: string,
+    imageUrl: string,
     date: string,
-    sort: MagazineSort
+    category: string
 };
 
 export interface NewsCardProps {
-    src: string,
-    href: string,
-    newsHref: string,
+    id: number,
     title: string,
+    imageUrl: string,
+    date: string,
+    link: string,
+    albumId: number
 };
 
 export interface MixtapeCardProps {
-    src: string,
-    href: string,
+    id: number,
     title: string,
-    artist: string
+    subTitle: string,
+    description: string,
+    imageUrl: string,
+    customized: boolean
 };
 
 export interface AlbumCardProps {
-    src: string,
-    href: string,
+    id: number,
     title: string,
-    artist: string
+    description: string,
+    releaseDate: string,
+    imageUrl: string,
+    artist: {
+        id: number,
+        name: string,
+    }
 };
 
 export interface PlaylistCardProps {
-    src: string,
-    href: string,
+    id: number,
     title: string,
-    description: string
+    subTitle: string,
+    description: string,
+    imageUrl: string,
+    customized: boolean
 };
 
  export interface LibraryArtistThumbnailProps {
-    name: string;
-    src: string;
-    href: string;
+    name: string,
+    src: string,
+    href: string
 }
 
 export interface NormalArtistThumbnailProps {
-    name: string;
-    src: string;
-    href: string;
+    id: number,
+    name: string,
+    imageUrl: string,
+    genre: {
+        id: number,
+        name: string,
+    }
 }
 
 export interface ChartCardProps {
-    src: string;
-    rank: number;
-    artist: string;
-    trackTitle: string;
+    id: number,
+    rank: number,
+    title: string,
+    album: {
+        id: number,
+        imageUrl: string,
+    },
+    artist: {
+        id: number,
+        name: string,
+    }
 }
 
 export interface TrackRowCardProps {
-    trackId: string, 
-    albumImgSrc: string, 
-    trackTitle: string, 
-    artist : string, 
-    albumTitle: string,
-    href: string,
-    lyrics: string
+    id: number,
+    title: string,
+    lyrics: string,
+    playtime: number,
+    albumId: number,
+    album: {
+        id: number,
+        title: string,
+        imageUrl: string
+    },
+    artist: {
+        id: number,
+        name: string
+    },
+    liked: boolean
 }
 
 export interface TrackCardProps {
-    src: string;
-    trackTitle: string;
-    artist: string;
-    imgVariant: 'trackRowCard' | 'trackInfo';
-    isDefault: boolean;
-    isTrack: boolean;
+    src: string,
+    trackTitle: string,
+    artist: string,
+    imgVariant: 'trackRowCard' | 'trackInfo',
+    isDefault: boolean,
+    isTrack: boolean,
 }
 
 export interface PlayerTrackCardProps {
-    src: string;
-    trackTitle: string;
-    artist: string;
+    src: string,
+    trackTitle: string,
+    artist: string,
 }

--- a/client/pages/album/sample.tsx
+++ b/client/pages/album/sample.tsx
@@ -5,42 +5,46 @@ import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    lyrics: '아직 없음ㅎ'
-});
-
 const albumData = 
 {
-    src: "https://musicmeta-phinf.pstatic.net/album/004/491/4491829.jpg?type=r360Fll&v=20200808020212",
-    title: "Rio Loves Tokyo Part 1",
-    artist: "김승민",
-    releasedDate: "2020.03.20",
-    genre: "랩/힙합",
-    description: `1. 10°0' 0° N 118°50 0° E (Feat. ASH ISLAND)
-    LYRICS BY 김승민, ASH ISLAND
-    COMPOSED BY 김승민, Minit, Chiic
-    ARRANGED BY Minit, Chiic
-    GUITAR BY Chiic
-    Mixed by 배재한 @등대사운드
-    Mastered by 배재한 @등대사운드
-        
-    2. MIA
-    LYRICS BY 김승민
-    COMPOSED BY 김승민, Minit, Chiic
-    ARRANGED BY Minit, Chiic
-    GUITAR BY Chiic
-    Mixed by 배재한 @등대사운드`
+    id: 11,
+    title: "그냥",
+    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
+    releaseDate: "2020-05-07",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    artist: {
+        id: 3,
+        name: "이영지"
+    },
+    tracks: [
+        {
+            id: 4,
+            title: "그냥",
+            artist: {
+                id: 3,
+                name: "이영지"
+            },
+            album: {
+                id: 11,
+                title: "그냥",
+                imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg"
+            },
+            liked: 0
+        }
+    ]
 }
 
+const TrackDatas = albumData.tracks;
+
+
 const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
+    id: 3,
+    name: "이영지",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+    genre: {
+        id: 1,
+        name: "랩/힙합"
+    }
 });
 
 const Container = styled.div`

--- a/client/pages/artist/sample.tsx
+++ b/client/pages/artist/sample.tsx
@@ -5,23 +5,103 @@ import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    lyrics: '아직 없음ㅎ'
-});
-
 const artistData = {
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
-    genre: '랩/힙합'
-}
+    id: 3,
+    name: "이영지",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+    genre: {
+        "name": "랩/힙합"
+    },
+    tracks: [
+        {
+            id: 4,
+            title: "그냥",
+            lyrics: "keep callin' to me\n왜 인지는 묻지 말아 주면은 안돼?\njust text me \n밥은 잘 먹고 있는지에 대해\n뭔들 난 다 좋아\n별거 없는 그런 삶\nim so sick of these days\n말해 줘 너의 밤은 어때\n또 너의 날은 어떻고?\n나의 시간은 못 돼서\n다시 이 굴레에 날 가둬  \n이 밤은 또 내껄\n자꾸만 뺏으려 들어\nwhere should i go right now? \n\n뭘 쥐어도 다 모래\n결국 흐르니 난 뭘 해?  \n못 된 생각이 인내를 놓을땐 \n도태 되는거야 no thanks\n가지면 뭐해\ni got nothing to prove no\n사랑을 할래\n위기는 모르는 채로 oh \n너 불안정한 내게\n자꾸 깊은 믿음을 심어주지마\n나도 모르는 새에\n널 내 안에 들여놓고 착각 할지도 몰라\n\npainful thoughts \nin ma head \n다 모순인 거야\n비운의 틈새로\n나 겨울의 냄새를 맡고파\npainful thoughts\nim ma head \n다 거짓인 거야\n난 그저 여름의 향수에만 잠깐 젖고파\ncuz im bored\n아늑하기만 한\n나의 방은 어두워서\n상처는 아물지  않아\n날 봐줘\n저 멀리 가고 있는\n날 보게 된다면은 붙잡아줘 ",
+            playtime: 217,
+            albumId: 11,
+            artist: {
+                id: 3,
+                name: "이영지"
+            },
+            album: {
+                id: 11,
+                title: "그냥",
+                imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg"
+            },
+            liked: 0
+        },
+        {
+            id: 6,
+            title: "암실",
+            lyrics: "농도가 아주 짙은\n랩을 뱉어도\n네 안에 쌓인 독\n덜어 낼 수 없어\n팔리는 음악은\n누가 찍어\n모자란 걸\n양심을 잃은 돈 거머쥘 수 없어\n\n더 벌어서\n더 버려 벗겨지는 마음\n개나 준 채로 숨어 암전 속으로\n나 바뻐\n좌절도 늘 그랬듯이 힘이 쭉 빠져\n밉상이니 맘껏 비웃어\n\n난 찾아야 돼 exit 작업실 의자 뒤에\n문 말고 딜레마 속 지랄맞은 굴레 i mean\n지피지기 면백전 백승 은 나발이고\n다물어 이 방 안에 내 적은 나뿐임\nuh 나는 나를 알아 점점 퇴보해 가\n구멍난 스타킹 안 꿰매 신어도 되는데\n나 왜이리 빈곤한 걸까\n묻지 말아줘 맘이 공허한 걸까\n\n아직 잃을 준비가 안 된 것 같아서 좀 많이 두려워\n돈 명예 시계 전부 얻어도 날 다 채울 수 가 없으니\n더 날 불러줘 막연한 회의감 가득한 방 안에서도 듣게끔\n\nplease 날 나가게 해줘\n좀 더 잃을 게 많아져도\ni can't do this no more\nso please 날 나가게 해줘\n날 지워낸 다음 덮어내 다시\nblack 을 제외한 색깔로 more\nso please 날 나가게\n날아가게 해줘\nso please 날 나가게\n날아가게 해줘\nso please 날 나가게\n날아가게 해줘\nso please 날 나가게\n날아가게 해줘",
+            playtime: 152,
+            albumId: 12,
+            artist: {
+                id: 3,
+                name: "이영지"
+            },
+            album: {
+                id: 12,
+                title: "암실",
+                imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/399/3399784.jpg"
+            },
+            liked: 0
+        }
+    ],
+    albums: [
+        {
+            id: 11,
+            title: "그냥",
+            imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg"
+        },
+        {
+            id: 12,
+            title: "암실",
+            imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/399/3399784.jpg"
+        }
+    ]
+};
 
-const Artistdata = Array(9).fill(artistData);
+const TrackDatas = artistData.tracks;
+
+const Artistdata = [
+    {
+        "id": 3,
+        "name": "이영지",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+        "genre": {
+            "id": 1,
+            "name": "랩/힙합"
+        }
+    },
+    {
+        "id": 4,
+        "name": "BLACKPINK",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/000/500/500555.jpg",
+        "genre": {
+            "id": 2,
+            "name": "댄스"
+        }
+    },
+    {
+        "id": 5,
+        "name": "백예린",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/000/234/234253.jpg",
+        "genre": {
+            "id": 3,
+            "name": "알앤비/소울"
+        }
+    },
+    {
+        "id": 6,
+        "name": "새소년",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/000/829/829598.jpg?type=ff300_300&v=20200510175911",
+        "genre": {
+            "id": 4,
+            "name": "인디뮤직"
+        }
+    }
+];
 
 const Container = styled.div`
     min-height: 1300px;
@@ -54,7 +134,7 @@ const Artist = () => {
     return (
         <Container>
             <Header>
-                <ArtistHeader src = { artistData.src } name = { artistData.name } genre = { artistData.genre }/>
+                <ArtistHeader src = { artistData.imageUrl } name = { artistData.name } genre = { artistData.genre.name }/>
             </Header>
             <ContentsContainer>
                 <ContentsButtonGroup />

--- a/client/pages/chart.tsx
+++ b/client/pages/chart.tsx
@@ -31,17 +31,29 @@ const ChartContainer = styled.div`
 `;
 
 const ChartCards: ChartCardProps[] = Array(30).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
+    id: 5,
     rank: 1,
-    artist: '방탄소년단',
-    trackTitle: 'dynamite',
+    title: '그냥',
+    album: {
+        id: 0,
+        imageUrl: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
+    },
+    artist: {
+        id: 0,
+        name: '이영지',
+    }
 });
 
 const Albumdata = Array(9).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/album/005/102/5102890.jpg?type=r360Fll&v=20201123123608',
-    href: 'localhost:3000',
-    title: 'Blue Skies',
-    artist: 'Birdy',
+    id: 11,
+    title: "그냥",
+    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
+    releaseDate: "2020-05-07",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    artist: {
+        id: 3,
+        name: "이영지"
+    }
 });
 
 const Chart = () => {

--- a/client/pages/genre/sample.tsx
+++ b/client/pages/genre/sample.tsx
@@ -27,34 +27,88 @@ const ContentsContainer = styled.div`
 `;
 
 const Albumdata = Array(9).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/album/005/102/5102890.jpg?type=r360Fll&v=20201123123608',
-    href: 'localhost:3000',
-    title: 'Blue Skies',
-    artist: 'Birdy',
+    id: 11,
+    title: "그냥",
+    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
+    releaseDate: "2020-05-07",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    artist: {
+        id: 3,
+        name: "이영지"
+    }
 });
+
 const Chartdata = Array(30).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
+    id: 5,
     rank: 1,
-    artist: '방탄소년단',
-    trackTitle: 'dynamite',
+    title: '그냥',
+    album: {
+        id: 0,
+        imageUrl: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
+    },
+    artist: {
+        id: 0,
+        name: '이영지',
+    }
 });
-const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
-});
+
+const Artistdata = [
+    {
+        "id": 3,
+        "name": "이영지",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+        "genre": {
+            "id": 1,
+            "name": "랩/힙합"
+        }
+    },
+    {
+        "id": 4,
+        "name": "BLACKPINK",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/000/500/500555.jpg",
+        "genre": {
+            "id": 2,
+            "name": "댄스"
+        }
+    },
+    {
+        "id": 5,
+        "name": "백예린",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/000/234/234253.jpg",
+        "genre": {
+            "id": 3,
+            "name": "알앤비/소울"
+        }
+    },
+    {
+        "id": 6,
+        "name": "새소년",
+        "imageUrl": "https://musicmeta-phinf.pstatic.net/artist/000/829/829598.jpg?type=ff300_300&v=20200510175911",
+        "genre": {
+            "id": 4,
+            "name": "인디뮤직"
+        }
+    }
+];
+
 const FeaturedPlaylistdata = Array(9).fill({
-    src: 'https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png',
-    href: 'localhost:3000',
-    title: '한국 힙합 트렌드',
-    description: 'VIBE 국내 힙합',
+    id: 1,
+    title: "VIBE AND CHILL",
+    subTitle: "",
+    description: "VIBE",
+    imageUrl: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
+    customized: false
 });
-const ArtistPlaylistdata = Array(10).fill({
-    title: '이영지 대표곡',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=f674_674_repre3&v=2020113005',
-    href: '#',
-    description: 'VIBE',
+
+const ArtistPlaylistdata = Array(9).fill({
+    id: 1,
+    title: "VIBE AND CHILL",
+    subTitle: "",
+    description: "VIBE",
+    imageUrl: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
+    customized: false
 });
+
 const GenreData = {
     id: 1,
     title: '국내 힙합',

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -9,52 +9,59 @@ import Link from 'next/link';
 
 const mainMagazineData = 
 {
-    src: "https://music-phinf.pstatic.net/20201119_255/1605768990292DkTAH_JPEG/%B4%EB%C7%A5-%C0%CC%B9%CC%C1%F61.jpg?type=w720",
-    href: "localhost:3000",
+    id: 0,
+    imageUrl: "https://music-phinf.pstatic.net/20201119_255/1605768990292DkTAH_JPEG/%B4%EB%C7%A5-%C0%CC%B9%CC%C1%F61.jpg?type=w720",
     title: "차트를 달리는 래퍼 : 잭 할로우, 물라토",
     description: "아직 한 달 남짓한 시간이 남았지만, 2020년 역시 힙합의 해라고 해도 과언이 아니지 않을까? 신인을 비롯한 수많은 힙합 아티스트들이 빌보드 HOT 차트 상위권을 거쳐가며 인기를 끌었기 때문이다. 그런데 최근 힙합을 잘 챙겨 듣지 않은 이들에게는 신인의 이름이 낯설 수도 있다. 올해가 가기 전 이름을 알아 두면 좋을 일곱 명의 래퍼를 확인해보자. - 힙합엘이",
-    label: "GENRE"
+    date: "2020-11-19",
+    category: "gerne"
 }
 
 const Magazinesdata = Array(9).fill({
-    src: 'https://music-phinf.pstatic.net/20201116_25/1605515795782Xy0Kf_JPEG/0-%B4%EB%C7%A5%C0%CC%B9%CC%C1%F6-%C1%A4%B9%E6%C7%FC_11.jpg?type=w720',
-    href: '/magazines/sample',
-    title: "나만 없어 그 한정판 LP 레코드",
-    date: '2020.11.19',
-    sort: MagazineSort.main,
-});
+        id: 1,
+        title: "나만 없어 그 한정판\nLP 레코드",
+        imageUrl: "https://music-phinf.pstatic.net/20201116_25/1605515795782Xy0Kf_JPEG/0-%B4%EB%C7%A5%C0%CC%B9%CC%C1%F6-%C1%A4%B9%E6%C7%FC_11.jpg?type=w720",
+        date: "2020-11-19",
+        category: "gerne"
+    });
 
 const Newsdata = Array(9).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
-    title: `이영지가 새 앨범을 발표했습니다`,
+    id: 2,
+    title: "블랙핑크가 데뷔 첫 온라인 콘서트를 합니다",
+    imageUrl: "https://music-phinf.pstatic.net/20201204_242/1607046595052EDJxR_JPEG/blackpink_400.jpg?type=f310_182",
+    date: "2020-12-06",
+    link: "https://www.yna.co.kr/view/AKR20201203094500005?section=entertainment/pop-song",
+    albumId: 9
 });
 
 const Albumdata = Array(9).fill({
-    src: "https://musicmeta-phinf.pstatic.net/album/005/102/5102890.jpg?type=r360Fll&v=20201123123608",
-    href: 'localhost:3000',
-    title: "Blue Skies",
-    artist: "Birdy"
-});
-
-const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
+    id: 11,
+    title: "그냥",
+    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
+    releaseDate: "2020-05-07",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    artist: {
+        id: 3,
+        name: "이영지"
+    }
 });
 
 const Mixtapedata = Array(9).fill({
-    src: "https://vibeapp.music.naver.com/vibe/v1/cover/mix/3171155,2487724,3553414,635724/favorite/favorite/",
-    href: 'localhost:3000',
+    id: 1,
     title: "나를 위한 믹스테잎",
-    artist: "Lana Del Rey, Dua Lipa, 이영지"
+    subTitle: "",
+    description: "Lana Del Rey, Dua Lipa, 이영지",
+    imageUrl: "https://vibeapp.music.naver.com/vibe/v1/cover/mix/3171155,2487724,3553414,635724/favorite/favorite/",
+    customized: false
 });
 
 const Playlistdata = Array(9).fill({
-    src: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
-    href: 'localhost:3000',
+    id: 1,
     title: "VIBE AND CHILL",
-    description: "VIBE"
+    subTitle: "",
+    description: "VIBE",
+    imageUrl: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
+    customized: false
 });
 
 const TodayContainer = styled.div`

--- a/client/pages/library/albums.tsx
+++ b/client/pages/library/albums.tsx
@@ -3,10 +3,15 @@ import LibraryHeader from '@components/organisms/Library/LibraryHeader/LibraryHe
 import LibraryCardList from '@components/organisms/Library/LibraryCardList/LibraryCardList';
 
 const Albumdata = Array(9).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/album/005/102/5102890.jpg?type=r360Fll&v=20201123123608',
-    href: '/album/sample',
-    title: 'Blue Skies',
-    artist: 'Birdy',
+    id: 11,
+    title: "그냥",
+    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
+    releaseDate: "2020-05-07",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    artist: {
+        id: 3,
+        name: "이영지"
+    }
 });
 
 const LibraryContainer = styled.div`

--- a/client/pages/library/artists.tsx
+++ b/client/pages/library/artists.tsx
@@ -3,9 +3,13 @@ import LibraryHeader from '@components/organisms/Library/LibraryHeader/LibraryHe
 import LibraryCardList from '@components/organisms/Library/LibraryCardList/LibraryCardList';
 
 const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: '/artist/sample',
+    id: 3,
+    name: "이영지",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+    genre: {
+        id: 1,
+        name: "랩/힙합"
+    }
 });
 
 const LibraryContainer = styled.div`

--- a/client/pages/library/mixtapes.tsx
+++ b/client/pages/library/mixtapes.tsx
@@ -3,10 +3,12 @@ import LibraryHeader from '@components/organisms/Library/LibraryHeader/LibraryHe
 import LibraryCardList from '@components/organisms/Library/LibraryCardList/LibraryCardList';
 
 const Mixtapedata = Array(9).fill({
-    src: 'https://vibeapp.music.naver.com/vibe/v1/cover/mix/3171155,2487724,3553414,635724/favorite/favorite/',
-    href: '/mixtape/sample',
-    title: '나를 위한 믹스테잎',
-    artist: 'Lana Del Rey, Dua Lipa, 이영지',
+    id: 1,
+    title: "나를 위한 믹스테잎",
+    subTitle: "",
+    description: "Lana Del Rey, Dua Lipa, 이영지",
+    imageUrl: "https://vibeapp.music.naver.com/vibe/v1/cover/mix/3171155,2487724,3553414,635724/favorite/favorite/",
+    customized: false
 });
 
 const LibraryContainer = styled.div`

--- a/client/pages/library/playlists.tsx
+++ b/client/pages/library/playlists.tsx
@@ -3,10 +3,12 @@ import LibraryHeader from '@components/organisms/Library/LibraryHeader/LibraryHe
 import LibraryCardList from '@components/organisms/Library/LibraryCardList/LibraryCardList';
 
 const PlaylistData = Array(9).fill({
-    src: 'https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png',
-    href: '/playlist/sample',
-    title: 'VIBE 추천 플레이리스트',
-    description: 'VIBE',
+    id: 1,
+    title: "VIBE AND CHILL",
+    subTitle: "",
+    description: "VIBE",
+    imageUrl: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
+    customized: false
 });
 
 const LibraryContainer = styled.div`

--- a/client/pages/library/tracks.tsx
+++ b/client/pages/library/tracks.tsx
@@ -3,14 +3,25 @@ import LibraryHeader from '@components/organisms/Library/LibraryHeader/LibraryHe
 import TrackRowList from '@components/organisms/CardLists/TrackRowList';
 import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    lyrics: '아직 없음ㅎ'
-});
+const data = {
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 1
+}
+
+const TrackDatas = Array(20).fill(data);
 
 const LibraryContainer = styled.div`
     width: 100%;

--- a/client/pages/magazines.tsx
+++ b/client/pages/magazines.tsx
@@ -6,23 +6,22 @@ import MainMagazineCard from '@components/organisms/Cards/MainMagazineCard/MainM
 import { MagazineSort } from '@interfaces/props';
 import MagazineList from '@components/organisms/CardLists/MagazineList/MagazineList';
 
-const mainMagazineData = {
-    src:
-        'https://music-phinf.pstatic.net/20201119_255/1605768990292DkTAH_JPEG/%B4%EB%C7%A5-%C0%CC%B9%CC%C1%F61.jpg?type=w720',
-    href: 'localhost:3000',
-    title: '차트를 달리는 래퍼 : 잭 할로우, 물라토',
-    description:
-        '아직 한 달 남짓한 시간이 남았지만, 2020년 역시 힙합의 해라고 해도 과언이 아니지 않을까? 신인을 비롯한 수많은 힙합 아티스트들이 빌보드 HOT 차트 상위권을 거쳐가며 인기를 끌었기 때문이다. 그런데 최근 힙합을 잘 챙겨 듣지 않은 이들에게는 신인의 이름이 낯설 수도 있다. 올해가 가기 전 이름을 알아 두면 좋을 일곱 명의 래퍼를 확인해보자. - 힙합엘이',
-    label: 'GENRE',
-};
+const mainMagazineData = 
+{
+    id: 0,
+    imageUrl: "https://music-phinf.pstatic.net/20201119_255/1605768990292DkTAH_JPEG/%B4%EB%C7%A5-%C0%CC%B9%CC%C1%F61.jpg?type=w720",
+    title: "차트를 달리는 래퍼 : 잭 할로우, 물라토",
+    description: "아직 한 달 남짓한 시간이 남았지만, 2020년 역시 힙합의 해라고 해도 과언이 아니지 않을까? 신인을 비롯한 수많은 힙합 아티스트들이 빌보드 HOT 차트 상위권을 거쳐가며 인기를 끌었기 때문이다. 그런데 최근 힙합을 잘 챙겨 듣지 않은 이들에게는 신인의 이름이 낯설 수도 있다. 올해가 가기 전 이름을 알아 두면 좋을 일곱 명의 래퍼를 확인해보자. - 힙합엘이",
+    date: "2020-11-19",
+    category: "gerne"
+}
 
 const Magazinesdata = Array(9).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
-    title: `이 주의 디깅 #77 
-    이영지 새 앨범 발표`,
-    date: '2020.11.25',
-    sort: MagazineSort.main,
+    id: 1,
+    title: "나만 없어 그 한정판\nLP 레코드",
+    imageUrl: "https://music-phinf.pstatic.net/20201116_25/1605515795782Xy0Kf_JPEG/0-%B4%EB%C7%A5%C0%CC%B9%CC%C1%F6-%C1%A4%B9%E6%C7%FC_11.jpg?type=w720",
+    date: "2020-11-19",
+    category: "gerne"
 });
 
 const Container = styled.div`

--- a/client/pages/magazines/sample.tsx
+++ b/client/pages/magazines/sample.tsx
@@ -15,85 +15,133 @@ const MagazineHeaderData = {
     href: '/playlist/sample'
 }
 
+const magData = {
+    id: 1,
+    title: "나만 없어 그 한정판\nLP 레코드",
+    imageUrl: "https://music-phinf.pstatic.net/20201116_25/1605515795782Xy0Kf_JPEG/0-%B4%EB%C7%A5%C0%CC%B9%CC%C1%F6-%C1%A4%B9%E6%C7%FC_11.jpg?type=w720",
+    date: "2020-11-19",
+    category: "gerne",
+    playlist: {
+        id: 1,
+        description: null,
+        tracks: [
+            {
+                id: 1,
+                title: "Square",
+                lyrics: "All the colors and personalities\n모든 색깔과 성격들 \nyou can’t see right through what I truly am\n그것들 사이로는 내가 정말 어떤 사람인지 볼 수 없어\nyou’re hurting me without noticing \n넌 예고도 없이 나에게 상처를 주고 \nI’m so, so broke like someone just robbed me\n누가 날 털어간 것 마냥 부서진 것 같아\n\nI’m no invincible\n난 강한 사람이 아니야\nI have much memories of getting more weaker \n난 점점 약해져가는 기억들이 훨씬 많은 걸\nI know I’m not loveable\n나도 내가 사랑받을 수 없는 거 알아\nbut you know what you’d have to say\n그래도 네가 어떤 말을 해줘야 하는지 알지?\n\n\n“Come on let’s go to bed \n“나와 같이 침대로 가자 \nwe gonna rock the night away\n우린 이 밤을 신나게 보낼 거야\nwho did that to you, babe\n누가 너에게 그런 짓을 한 거야\nIf you’re not in the right mood to sleep now then, \n네가 당장 잠들 수 있는 기분이 아니라면 \nCome on, let’s drink and have very unmanageable day \n나와서 나랑 한잔하고, 감당하기 힘든 하루를 보내자!\nwould you want me in bae\n내가 거기 있길 바라?\nIf you’re not in the right mood to sleep now then \n네가 당장 잠들 수 있는 기분이 아니라면 \ncome take my arms and go \n나와 함께 가자!\nI’II be yours for sure”\n내가 너의 것이 되어줄게!” ",
+                playtime: 261,
+                albumId: 10,
+                album: {
+                    id: 10,
+                    title: "Every letter I sent you.",
+                    imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+                },
+                artist: {
+                    id: 5,
+                    name: "백예린"
+                },
+                liked: 1
+            },
+            {
+                id: 2,
+                title: "Popo (How deep is our love?)",
+                lyrics: "Get away from your own sorrow\n슬픔에서 벗어나봐요\nLet the sun come through your window\n당신의 창문에 햇살이 들어오게 해봐요\nYou don’t have to open up wide \n마음을 활짝 열 필요는 없지만\nBut I want to intimate\n전 가까워지고 싶어요 \n\n\nYou’ll never know how much your voice attracts me, boy\n당신은 당신 목소리가 날 얼마나 끌리게 하는지 모를 거예요\nIt’s exceptional\n정말 특별해요\nEspecially, when you’re playing the song for me\n특히 날 위해 곡을 연주할 땐\nI can’t take my eyes away\n눈을 뗄 수 없어요\n\n\nCan I walk with you? \n당신과 걸을 수 있을까요\nor have a tea with you\n차를 마셔도 좋아요\nYour scent makes me feel like I live in Paris \n당신의 향기는 내가 마치 파리에 살고 있는 것처럼 느끼게 해요\nCan I love you?\n사랑해도 될까요?\ngiving my all to you?\n내 전부를 다 주는 것도요 \nyou \n당신에게요",
+                playtime: 261,
+                albumId: 10,
+                album: {
+                    id: 10,
+                    title: "Every letter I sent you.",
+                    imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+                },
+                artist: {
+                    id: 5,
+                    name: "백예린"
+                },
+                liked: 0
+            },
+            {
+                id: 3,
+                title: "0310",
+                lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+                playtime: 250,
+                albumId: 10,
+                album: {
+                    id: 10,
+                    title: "Every letter I sent you.",
+                    imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+                },
+                artist: {
+                    id: 5,
+                    name: "백예린"
+                },
+                liked: 1
+            }
+        ]
+    }
+}
+
 const MagazineData = [
     {
     title: '백예린 - Every Letter I Sent you',
     src: 'https://music-phinf.pstatic.net/20201116_134/1605515912711lcfoe_JPEG/1_%B9%E9%BF%B9%B8%B0.jpeg',
     description: '발매되기 전부터 이토록 화제를 모은 앨범이 2020년에 또 있었을까. JYP를 나간 후 백예린이 발표한 앨범 <Every letter i sent you>는 발매 전부터 후까지 쉬지 않고 크고 작은 화제를 모았다. 음원으로 발표되지 않아 많은 사람들이 라이브 영상 클립으로만 보고 들었던 ‘Square’가 수록된 것을 포함해, 18곡에 이르는 더블 시디 분량의 곡 수. 전 곡을 영어로 부른 것까지 기존 대중가요계에서는 찾기 힘든 파격이 돋보이는 앨범이었다. 2,000장 한정으로 발매된 한정판 투명 블루디스크 LP 레코드가 1분도 안 돼 동나는 건 당연한 일. 안타까운 건 이를 구입한 이들 중에는 재판매(리셀)을 목적으로 프리미엄(플미)를 붙여 판매하려는 업자도 속해 있었다는 점이다. 결국 백예린은 이후 예약 구매를 받아 제작하는 형태로 다시 LP 레코드를 제작했다. 그 역시 현재는 플미 거래되고 있다고. 이래저래 대단한 백예린이다.',
-    tracks: [
-        {
-            albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r480Fll&v=20200218131210',
-            trackId: '1',
-            trackTitle: 'Squre (2017)',
-            artist: '백예린',
-            albumTitle: 'Every letter I sent you.',
-            href: '/track/sample',
-            lyrics: '아직 없음ㅎ'
-        },
-        {
-            albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r480Fll&v=20200218131210',
-            trackId: '1',
-            trackTitle: 'Popo (How deep is our love?)',
-            artist: '백예린',
-            albumTitle: 'Every letter I sent you.',
-            href: '/track/sample',
-            lyrics: '아직 없음ㅎ'
-        },
-        {
-            albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r480Fll&v=20200218131210',
-            trackId: '1',
-            trackTitle: '0310',
-            artist: '백예린',
-            albumTitle: 'Every letter I sent you.',
-            href: '/track/sample',
-            lyrics: '아직 없음ㅎ'
-        },
-    ]
+    tracks: magData.playlist.tracks
     },
-    {
-        title: '이소라 - 눈썹달',
-        src: 'https://music-phinf.pstatic.net/20201116_263/1605516347825ddHwx_JPEG/4_%C0%CC%BC%D2%B6%F3.jpg',
-        description: `바이닐 붐이 일면서 가장 좋은 점 중 하나는 과거의 명반을 커다란 LP 레코드를 통해 다시 소장할 수 있는 기쁨이다. 대신 아쉬운 점도 있는데 대부분의 음반이 재빨리 클릭하지 않으면 구할 수 없을뿐더러 그중 상당수가 리셀러에게 비싼 가격에 판매된다는 점이다. 최근에는 이를 막기 위해 사전예약을 받은 후 LP 레코드를 제작하는 경우도 있지만, 모든 제작자가 그렇게 친절하진 않다. 이소라의 <눈썹달>은 재발매되기 딱 좋은 요건을 갖춘 음반이다. '바람이 분다'라는 명곡 수록, 아름다운 앨범 디자인, 거기다 활동이 드문 이소라라는 가수의 신비로움까지. 이소라의 <눈썹달>은 천으로 만든 커버와 두 장의 보라색 LP로 발매 전부터 많은 이의 기대를 모았다. 하지만 지나치게 높은 가격과 겉에 비해 허전한 부클릿, A면이 모노로 녹음되어 있다는 소문과 나쁜 음질로 발매 후 리콜 논란에 휩싸이기도 했다. 그와 상관없이 음반은 리셀러에게 비싸게 판매되고 있지만.`,
-        tracks: [
-            {
-                albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/000/029/29410.jpg?type=r480Fll&v=20191212155250',
-                trackId: '1',
-                trackTitle: '바람이 분다',
-                artist: '이소라',
-                albumTitle: '눈썹달',
-                href: '/track/sample',
-                lyrics: '아직 없음ㅎ'
-            },
-            {
-                albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/000/029/29410.jpg?type=r480Fll&v=20191212155250',
-                trackId: '1',
-                trackTitle: '이제 그만',
-                artist: '이소라',
-                albumTitle: '눈썹달',
-                href: '/track/sample',
-                lyrics: '아직 없음ㅎ'
-            },
-            {
-                albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/000/029/29410.jpg?type=r480Fll&v=20191212155250',
-                trackId: '1',
-                trackTitle: '시시콜콜한 이야기',
-                artist: '이소라',
-                albumTitle: '눈썹달',
-                href: '/track/sample',
-                lyrics: '아직 없음ㅎ'
-            },
-        ]
-    }
+    // {
+    //     title: '이소라 - 눈썹달',
+    //     src: 'https://music-phinf.pstatic.net/20201116_263/1605516347825ddHwx_JPEG/4_%C0%CC%BC%D2%B6%F3.jpg',
+    //     description: `바이닐 붐이 일면서 가장 좋은 점 중 하나는 과거의 명반을 커다란 LP 레코드를 통해 다시 소장할 수 있는 기쁨이다. 대신 아쉬운 점도 있는데 대부분의 음반이 재빨리 클릭하지 않으면 구할 수 없을뿐더러 그중 상당수가 리셀러에게 비싼 가격에 판매된다는 점이다. 최근에는 이를 막기 위해 사전예약을 받은 후 LP 레코드를 제작하는 경우도 있지만, 모든 제작자가 그렇게 친절하진 않다. 이소라의 <눈썹달>은 재발매되기 딱 좋은 요건을 갖춘 음반이다. '바람이 분다'라는 명곡 수록, 아름다운 앨범 디자인, 거기다 활동이 드문 이소라라는 가수의 신비로움까지. 이소라의 <눈썹달>은 천으로 만든 커버와 두 장의 보라색 LP로 발매 전부터 많은 이의 기대를 모았다. 하지만 지나치게 높은 가격과 겉에 비해 허전한 부클릿, A면이 모노로 녹음되어 있다는 소문과 나쁜 음질로 발매 후 리콜 논란에 휩싸이기도 했다. 그와 상관없이 음반은 리셀러에게 비싸게 판매되고 있지만.`,
+    //     tracks: [
+    //         {
+    //             albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/000/029/29410.jpg?type=r480Fll&v=20191212155250',
+    //             trackId: '1',
+    //             trackTitle: '바람이 분다',
+    //             artist: '이소라',
+    //             albumTitle: '눈썹달',
+    //             href: '/track/sample',
+    //             lyrics: '아직 없음ㅎ'
+    //         },
+    //         {
+    //             albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/000/029/29410.jpg?type=r480Fll&v=20191212155250',
+    //             trackId: '1',
+    //             trackTitle: '이제 그만',
+    //             artist: '이소라',
+    //             albumTitle: '눈썹달',
+    //             href: '/track/sample',
+    //             lyrics: '아직 없음ㅎ'
+    //         },
+    //         {
+    //             albumImgSrc: 'https://musicmeta-phinf.pstatic.net/album/000/029/29410.jpg?type=r480Fll&v=20191212155250',
+    //             trackId: '1',
+    //             trackTitle: '시시콜콜한 이야기',
+    //             artist: '이소라',
+    //             albumTitle: '눈썹달',
+    //             href: '/track/sample',
+    //             lyrics: '아직 없음ㅎ'
+    //         },
+    //     ]
+    // }
 ]
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    href: '/track/sample'
-});
+const data = {
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 1
+}
+
+const TrackDatas = Array(20).fill(data);
 
 const Container = styled.div`
     min-height: 1300px;

--- a/client/pages/mixtape/sample.tsx
+++ b/client/pages/mixtape/sample.tsx
@@ -7,24 +7,42 @@ import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 
 const mixtapeData = 
 {
-    src: "https://vibeapp.music.naver.com/vibe/v1/cover/mix/2487724,3553414,2836707,4551646/favorite/favorite/",
-    title: '최애 믹스테잎',
-    artist: "김승민, Ariana Grande, 이영지, Dua Lipa, Lana Del Rey"
+    id: 1,
+    title: "나를 위한 믹스테잎",
+    subTitle: "",
+    description: "Lana Del Rey, Dua Lipa, 이영지",
+    imageUrl: "https://vibeapp.music.naver.com/vibe/v1/cover/mix/3171155,2487724,3553414,635724/favorite/favorite/",
+    customized: false
 }
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    lyrics: '아직 없음ㅎ'
-});
+const data = {
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 1
+}
+
+const TrackDatas = Array(20).fill(data);
 
 const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
+    id: 3,
+    name: "이영지",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+    genre: {
+        id: 1,
+        name: "랩/힙합"
+    }
 });
 
 const Container = styled.div`

--- a/client/pages/playlist/sample.tsx
+++ b/client/pages/playlist/sample.tsx
@@ -7,24 +7,100 @@ import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 
 const playlistData = 
 {
-    src: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
-    title: "VIBE AND CHILL",
-    description: "VIBE"
+    "id": 2,
+    "title": "VIBE AND CHILL",
+    "subTitle": "",
+    "description": "VIBE",
+    "imageUrl": "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
+    "tracks": [
+        {
+            "id": 4,
+            "title": "그냥",
+            "lyrics": "keep callin' to me\n왜 인지는 묻지 말아 주면은 안돼?\njust text me \n밥은 잘 먹고 있는지에 대해\n뭔들 난 다 좋아\n별거 없는 그런 삶\nim so sick of these days\n말해 줘 너의 밤은 어때\n또 너의 날은 어떻고?\n나의 시간은 못 돼서\n다시 이 굴레에 날 가둬  \n이 밤은 또 내껄\n자꾸만 뺏으려 들어\nwhere should i go right now? \n\n뭘 쥐어도 다 모래\n결국 흐르니 난 뭘 해?  \n못 된 생각이 인내를 놓을땐 \n도태 되는거야 no thanks\n가지면 뭐해\ni got nothing to prove no\n사랑을 할래\n위기는 모르는 채로 oh \n너 불안정한 내게\n자꾸 깊은 믿음을 심어주지마\n나도 모르는 새에\n널 내 안에 들여놓고 착각 할지도 몰라\n\npainful thoughts \nin ma head \n다 모순인 거야\n비운의 틈새로\n나 겨울의 냄새를 맡고파\npainful thoughts\nim ma head \n다 거짓인 거야\n난 그저 여름의 향수에만 잠깐 젖고파\ncuz im bored\n아늑하기만 한\n나의 방은 어두워서\n상처는 아물지  않아\n날 봐줘\n저 멀리 가고 있는\n날 보게 된다면은 붙잡아줘 ",
+            "artist": {
+                "id": 3,
+                "name": "이영지"
+            },
+            "album": {
+                "id": 11,
+                "title": "그냥",
+                "imageUrl": "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg"
+            },
+            "liked": 0
+        },
+        {
+            "id": 5,
+            "title": "Lovesick Girls",
+            "lyrics": "영원한 밤\n창문 없는 방에 우릴 가둔 love\nWhat can we say\n매번 아파도 외치는 love\n\n다치고 망가져도 나\n뭘 믿고 버티는 거야\n어차피 떠나면 상처투성인 채로 미워하게 될걸\n끝장을 보기 전 끝낼 순 없어\n이 아픔을 기다린 것처럼\n\n아마 다 잠깐 일지도 몰라\n우린 무얼 찾아서 헤매는 걸까\n\nBut I don’t care I’ll do it over and over\n내 세상 속엔 너만 있으면 돼\n\nWe are the lovesick girls\n네 멋대로 내 사랑을 끝낼순 없어\nWe are the lovesick girls\n이 아픔 없인 난 아무 의미가 없어\n\nBut we were born to be alone\nYeah we were born to be alone\nYeah we were born to be alone \nBut why we still looking for love\n\nNo love letters, no x and o’s\nNo love never, my exes know\nNo diamond rings, that set in stone\nTo the left, better left alone\n\nDidn’t wanna be a princess, I’m priceless\nA prince not even on my list\nLove is a drug that I quit\nNo doctor could help when I’m lovesick",
+            "artist": {
+                "id": 4,
+                "name": "BLACKPINK"
+            },
+            "album": {
+                "id": 9,
+                "title": "THE ALBUM",
+                "imageUrl": "https://musicmeta-phinf.pstatic.net/album/004/983/4983288.jpg?type=r360Fll&v=20201106182509"
+            },
+            "liked": 1
+        },
+        {
+            "id": 1,
+            "title": "Square",
+            "lyrics": "All the colors and personalities\n모든 색깔과 성격들 \nyou can’t see right through what I truly am\n그것들 사이로는 내가 정말 어떤 사람인지 볼 수 없어\nyou’re hurting me without noticing \n넌 예고도 없이 나에게 상처를 주고 \nI’m so, so broke like someone just robbed me\n누가 날 털어간 것 마냥 부서진 것 같아\n\nI’m no invincible\n난 강한 사람이 아니야\nI have much memories of getting more weaker \n난 점점 약해져가는 기억들이 훨씬 많은 걸\nI know I’m not loveable\n나도 내가 사랑받을 수 없는 거 알아\nbut you know what you’d have to say\n그래도 네가 어떤 말을 해줘야 하는지 알지?\n\n\n“Come on let’s go to bed \n“나와 같이 침대로 가자 \nwe gonna rock the night away\n우린 이 밤을 신나게 보낼 거야\nwho did that to you, babe\n누가 너에게 그런 짓을 한 거야\nIf you’re not in the right mood to sleep now then, \n네가 당장 잠들 수 있는 기분이 아니라면 \nCome on, let’s drink and have very unmanageable day \n나와서 나랑 한잔하고, 감당하기 힘든 하루를 보내자!\nwould you want me in bae\n내가 거기 있길 바라?\nIf you’re not in the right mood to sleep now then \n네가 당장 잠들 수 있는 기분이 아니라면 \ncome take my arms and go \n나와 함께 가자!\nI’II be yours for sure”\n내가 너의 것이 되어줄게!” ",
+            "artist": {
+                "id": 5,
+                "name": "백예린"
+            },
+            "album": {
+                "id": 10,
+                "title": "Every letter I sent you.",
+                "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+            },
+            "liked": 1
+        },
+        {
+            "id": 2,
+            "title": "Popo (How deep is our love?)",
+            "lyrics": "Get away from your own sorrow\n슬픔에서 벗어나봐요\nLet the sun come through your window\n당신의 창문에 햇살이 들어오게 해봐요\nYou don’t have to open up wide \n마음을 활짝 열 필요는 없지만\nBut I want to intimate\n전 가까워지고 싶어요 \n\n\nYou’ll never know how much your voice attracts me, boy\n당신은 당신 목소리가 날 얼마나 끌리게 하는지 모를 거예요\nIt’s exceptional\n정말 특별해요\nEspecially, when you’re playing the song for me\n특히 날 위해 곡을 연주할 땐\nI can’t take my eyes away\n눈을 뗄 수 없어요\n\n\nCan I walk with you? \n당신과 걸을 수 있을까요\nor have a tea with you\n차를 마셔도 좋아요\nYour scent makes me feel like I live in Paris \n당신의 향기는 내가 마치 파리에 살고 있는 것처럼 느끼게 해요\nCan I love you?\n사랑해도 될까요?\ngiving my all to you?\n내 전부를 다 주는 것도요 \nyou \n당신에게요",
+            "artist": {
+                "id": 5,
+                "name": "백예린"
+            },
+            "album": {
+                "id": 10,
+                "title": "Every letter I sent you.",
+                "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+            },
+            "liked": 0
+        },
+        {
+            "id": 3,
+            "title": "0310",
+            "lyrics": "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+            "artist": {
+                "id": 5,
+                "name": "백예린"
+            },
+            "album": {
+                "id": 10,
+                "title": "Every letter I sent you.",
+                "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+            },
+            "liked": 0
+        }
+    ]
 }
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    lyrics: '아직 없음ㅎ'
-});
+const TrackDatas = playlistData.tracks;
 
 const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
+    id: 3,
+    name: "이영지",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+    genre: {
+        id: 1,
+        name: "랩/힙합"
+    }
 });
 
 const Container = styled.div`

--- a/client/pages/this-month.tsx
+++ b/client/pages/this-month.tsx
@@ -7,25 +7,41 @@ import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 
 const playlistData = 
 {
-    src: "https://music-phinf.pstatic.net/20200109_13/15785370058255nAVe_PNG/%C0%CC%B4%DE%C0%C7%B3%EB%B7%A1_%C1%A4%B9%E6%C7%FC.png",
+    id: 2,
     title: "이달의 노래 11월",
-    description: "최근 발매되어 많은 사랑을 받은 곡들 중에서 VIBE DJ 느낌별 스테이션이 선택한 노래 입니다. 힙터질때, 신났을때, 우울할때, 사랑할때, 사랑했을때, 파티할때, 멍때릴때, 운동할때, 휴식할때 가장 어울리는 VIBE 11월의 느낌을 만나 보세요."
+    subTitle: "",
+    description: "최근 발매되어 많은 사랑을 받은 곡들 중에서 VIBE DJ 느낌별 스테이션이 선택한 노래 입니다. 힙터질때, 신났을때, 우울할때, 사랑할때, 사랑했을때, 파티할때, 멍때릴때, 운동할때, 휴식할때 가장 어울리는 VIBE 11월의 느낌을 만나 보세요.",
+    imageUrl: "https://music-phinf.pstatic.net/20200109_13/15785370058255nAVe_PNG/%C0%CC%B4%DE%C0%C7%B3%EB%B7%A1_%C1%A4%B9%E6%C7%FC.png",
 }
 
-const TrackDatas = Array(20).fill({
-    albumImgSrc: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    trackId: '1',
-    trackTitle: 'VVS (Feat. JUSTHIS) (Prod. GroovyRoom)',
-    artist: '미란이',
-    albumTitle: '쇼미더머니 9 Episode 1',
-    href: '/track/sample',
-    lyrics: '아직 없음ㅎ'
-});
+const data = {
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 1
+}
+
+const TrackDatas = Array(20).fill(data);
 
 const Artistdata = Array(9).fill({
-    name: '이영지',
-    src: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    href: 'localhost:3000',
+    id: 3,
+    name: "이영지",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg",
+    genre: {
+        id: 1,
+        name: "랩/힙합"
+    }
 });
 
 const Container = styled.div`

--- a/client/pages/track/sample.tsx
+++ b/client/pages/track/sample.tsx
@@ -6,137 +6,51 @@ import Text from '@components/atoms/Text';
 import AlbumCard from '@components/organisms/Cards/AlbumCard/AlbumCard';
 
 const trackData = {
-    src: 'https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg?type=r480Fll&v=20200507115931',
-    title: '그냥',
-    artist: '이영지',
-    lyrics: `keep callin' to me
-    왜 인지는 묻지 말아 주면은 안돼?
-    just text me 
-    밥은 잘 먹고 있는지에 대해
-    뭔들 난 다 좋아
-    별거 없는 그런 삶
-    im so sick of these days
-    말해 줘 너의 밤은 어때
-    또 너의 날은 어떻고?
-    나의 시간은 못 돼서
-    다시 이 굴레에 날 가둬  
-    이 밤은 또 내껄
-    자꾸만 뺏으려 들어
-    where should i go right now? 
-    
-    뭘 쥐어도 다 모래
-    결국 흐르니 난 뭘 해?  
-    못 된 생각이 인내를 놓을땐 
-    도태 되는거야 no thanks
-    가지면 뭐해
-    i got nothing to prove no
-    사랑을 할래
-    위기는 모르는 채로 oh 
-    너 불안정한 내게
-    자꾸 깊은 믿음을 심어주지마
-    나도 모르는 새에
-    널 내 안에 들여놓고 착각 할지도 몰라
-    
-    painful thoughts 
-    in ma head 
-    다 모순인 거야
-    비운의 틈새로
-    나 겨울의 냄새를 맡고파
-    painful thoughts
-    im ma head 
-    다 거짓인 거야
-    난 그저 여름의 향수에만 잠깐 젖고파
-    cuz im bored
-    아늑하기만 한
-    나의 방은 어두워서
-    상처는 아물지  않아
-    날 봐줘
-    저 멀리 가고 있는
-    날 보게 된다면은 붙잡아줘 
-    
-    time is tickin' when the love is begin
-    i can take you everywhere 
-    왜 망설이고 있어?
-    time is tickin' when the love is begin--
-    나와/ 밤을 새 아침이 없는 것처럼
-    time is tickin' when the love is begin
-    maybe we can find out/ the answer
-    time is tickin' when the love is begin  
-    oh 얘기를 해 잠은 충분해 난     
-    
-    잠은 충분해 매일
-    다 버려진 채 잠식당할까 그게 두려워 
-    넌, 넌 나를 찾고 있어?
-    내가 성급해 보이더라도 나를 꼭 안아줘
-    배고픈 내일이 와도
-    고대하던 것들이 다 무너져도
-    it doesn't matter anymore 
-    그냥 공허할 뿐인 거야
-    내가 쥐었던 게 다
-    스치듯 지나가니까
-    
-    난 아둔한 poor little girl  
-    나와 같이 가자 차피 재미를 볼 거는 너
-    닮았다니까 우린 
-    그렇게 굴지 마
-    난 괜히 다 포용을 하는 stupid uh uh
-    dumbass 너는 뭔데?
-    됐고 머릴 머릴 비워
-    나는 못 됐어
-    뻔해 우리의 결말
-    근데 난 아직도 답답해 왠지
-    
-    painful thoughts 
-    in ma head 
-    다 모순인 거야
-    비운의 틈새로
-    나 겨울의 냄새를 맡고파
-    painful thoughts 
-    im ma head 
-    다 거짓인 거야
-    난 그저 여름의 향수에만 잠깐 젖고파
-    cuz im boared
-    아늑하기만 한
-    나의 방은 어두워서 
-    상처는 아물지 않아
-    날 봐줘
-    저 멀리 가고 있는
-    날 보게 된다면은 붙잡아줘 
-    
-    time is tickin' when the love is begin
-    i can take you everywhere 
-    왜 망설이고 있어?
-    time is tickin' when the love is begin
-    나와 밤을 새 아침이 없는 것처럼
-    time is tickin' when the love is begin
-    maybe we can find out the answer
-    time is tickin' when the love is begin  
-    oh 얘기를 해 잠은 충분해 난  
-    
-    we can find out the answer
-    we can find out the answer
-    `,
+    id: 3,
+    title: "0310",
+    lyrics: "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+    playtime: 250,
+    albumId: 10,
+    album: {
+        id: 10,
+        title: "Every letter I sent you.",
+        imageUrl: "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+    },
+    artist: {
+        id: 5,
+        name: "백예린"
+    },
+    liked: 0
 };
 
 const albumdata = Array(9).fill({
-    src: 'https://musicmeta-phinf.pstatic.net/album/005/102/5102890.jpg?type=r360Fll&v=20201123123608',
-    href: 'localhost:3000',
-    title: 'Blue Skies',
-    artist: 'Birdy',
-});
+    id: 11,
+    title: "그냥",
+    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
+    releaseDate: "2020-05-07",
+    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    artist: {
+        id: 3,
+        name: "이영지"
+    }});
 
 const playlistdata = Array(9).fill({
-    src: 'https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png',
-    href: 'localhost:3000',
-    title: 'VIBE AND CHILL',
-    description: 'VIBE',
+    id: 1,
+    title: "VIBE AND CHILL",
+    subTitle: "",
+    description: "VIBE",
+    imageUrl: "https://music-phinf.pstatic.net/20200504_183/1588567824216rHHs6_PNG/VIBE_%B0%F8%C5%EB_VibeAndChill.png",
+    customized: false
 });
 
 const belongAlbumData = {
-    src: 'https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg?type=r480Fll&v=20200507115931',
-    title: '그냥',
-    artist: '이영지',
-    releasedDate: '2020.05.07',
+    id: trackData.album.id,
+    title: trackData.album.title,
+    imageUrl: trackData.album.imageUrl,
+    artist: {
+        id: trackData.artist.id,
+        name: trackData.artist.name
+    }
 };
 
 const Container = styled.div`
@@ -208,9 +122,7 @@ const Track = () => {
                     </ContentsHeader>
                     <BelongAlbum>
                         <AlbumCard
-                            title={belongAlbumData.title}
-                            artist={belongAlbumData.artist}
-                            src={belongAlbumData.src}
+                        { ...(belongAlbumData) }
                         />
                     </BelongAlbum>
                 </Contents>

--- a/server/src/routes/artists/artists.controller.ts
+++ b/server/src/routes/artists/artists.controller.ts
@@ -37,6 +37,7 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
                 'track',
                 'album.id',
                 'album.title',
+                'genre.name',
                 'album.imageUrl',
                 'track_album.id',
                 'track_album.title',


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 1 api 구현된대로 페이지에 데이터 뿌려주면 컴포넌트들이 가져가도록 수정 & 방식 최대한 통일
- [x] 작업 내역 2 키값이 필요한 컴포넌트들에게 id를 키값으로 심어줌
- [x] 작업 내역 3 페이지에 하드코딩 되어있는 데이터 형식을 바뀐 api 명세대로 수정
- [x] 작업 내역 4 아티스트 컨트롤러에서 개별 아티스트 조회 시 장르 정보도 가지고 오도록 수정
- [x] 작업 내역 5 트랙 로우 카드 & 트랙 로우 리스트 스토리 작성 / interface/props 변경
- [x] 작업 내역 6 차트 카드 타이틀과 가수 이름을 A태그로 변경 및 css 수정 & 트랙 로우 카드 가사 아이콘 material ui로 변경


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 뮤직 플레이어 관련 컴포넌트 & 매거진 상세 페이지는 추후에 수정해야 합니다
- 특이 사항 2 동적 라우팅은 대충 주소만 심어 놓았기 때문에 후에 수정해야 합니다
- 특이 사항 3 수정할 부분이 많아 차마 스토리는 작성하지 못했습니다ㅜㅜ 시간이 되는대로 작성하도록 하겠습니다
- 특이 사항 4 매거진 테이블에도 description 컬럼을 추가하면 좋을 것 같습니다
- 특이 사항 5 앨범 상세 조회 api에서 각 곡의 가사들까지 불러오는게 좋을 것 같습니다. 지금은 가사가 불러와지지 않아서 가사 모달창을 열면 빈칸으로 뜹니다.
- 특이 사항 6 현재 페이지 단위에서 저희가 작성한 api를 통해 가지고 오는 데이터 형식 그대로 뿌려주면 알아서 알맞은 곳에 가도록 수정했습니다. 다만 low level의 컴포넌트들을 건드리면 많이 꼬일 것 같아 organisms 정도의 컴포넌트들만 수정했습니다. 아마 더 low level의 컴포넌트들까지 건드릴 필요는 없을 것 같습니다.

<br/><br/>
