### PR TITLE
[BE] 매거진 테이블 필드 추가 및 상세 조회 API 수정 /  앨범 상세 조회 API 수정

### DIFF
--- a/server/src/models/Magazine.ts
+++ b/server/src/models/Magazine.ts
@@ -14,6 +14,15 @@ class Magazine {
     @Column()
     imageUrl: string;
 
+    @Column('text')
+    description: string;
+
+    @Column()
+    subTitle: string;
+
+    @Column('text')
+    content: string;
+
     @Column('date')
     date: Date;
 

--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -34,7 +34,7 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
             .loadRelationCountAndMap('track.liked', 'track.likeUsers', 'user',
                 (qb) => qb.andWhere('user.id = :userId', { userId }))
             .select([
-                'album', 'artist.id', 'artist.name', 'track.id', 'track.title',
+                'album', 'artist.id', 'artist.name', 'track.id', 'track.title', 'track.lyrics',
                 'track_artist.id', 'track_artist.name',
                 'track_album.id', 'track_album.title', 'track_album.imageUrl',
             ])

--- a/server/src/routes/magazines/magazines.controller.ts
+++ b/server/src/routes/magazines/magazines.controller.ts
@@ -34,7 +34,6 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
             .select([
                 'magazine',
                 'playlist.id',
-                'playlist.description',
                 'track',
                 'artist.id',
                 'artist.name',


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] Magazine 테이블 subTitle, description, content 필드 추가 및 상세 조회 API 수정
- [x] 앨범 상세 조회 시 트랙 가사 함께 보내도록 수정


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 매거진 상세 조회 시 subTitle, content, description 받도록 / 기존의 playlist.description은 삭제

<br/><br/>
