### PR TITLE
[FE] 플로팅 셀렉트 메뉴와 앨범, 플레이리스트 상세 페이지에서 UpNext로 추가하는 기능 구현

### DIFF
--- a/client/components/atoms/CheckBox/index.tsx
+++ b/client/components/atoms/CheckBox/index.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
 import styled from 'styled-components';
+
+import { selectTrack, unselectTrack } from 'reducers/selectedTrack';
+import { TrackRowCardProps } from 'interfaces/props';
 
 interface CheckBoxProps {
     id: string;
+    data: TrackRowCardProps;
 }
 
 const StyledCheckBox = styled.div`
@@ -31,11 +37,20 @@ const Input = styled.input`
     }
 `;
 
-const CheckBox = ({ id }: CheckBoxProps) => (
-    <StyledCheckBox>
-        <Input type="checkbox" id={id} />
-        <label htmlFor={id} />
-    </StyledCheckBox>
-);
+const CheckBox = ({ id, data }: CheckBoxProps) => {
+    const dispatch = useDispatch();
+    const [checked, setChecked] = useState(false);
+
+    const onChangeHandler = () => {
+        setChecked((checked) => (!checked));
+        !checked? dispatch(selectTrack(data)):dispatch(unselectTrack(data.id));
+    }
+
+    return(
+        <StyledCheckBox>
+            <Input type="checkbox" id={id} checked = {checked} onChange = {onChangeHandler}/>
+            <label htmlFor={id} />
+        </StyledCheckBox>
+        )};
 
 export default CheckBox;

--- a/client/components/molecules/PlayControllerButtons/index.tsx
+++ b/client/components/molecules/PlayControllerButtons/index.tsx
@@ -7,6 +7,8 @@ import RepeatOneIcon from '@material-ui/icons/RepeatOne';
 import PauseIcon from '@material-ui/icons/Pause';
 import SkipPreviousIcon from '@material-ui/icons/SkipPrevious';
 import SkipNextIcon from '@material-ui/icons/SkipNext';
+import { playPrevTrack, playNextTrack } from 'reducers/musicPlayer';
+import { useSelector, useDispatch } from 'react-redux';
 
 // interface PlayControllerProps {
 //     playing: boolean;
@@ -45,7 +47,16 @@ const SubIconWrapper = styled.button`
 `;
 
 const PlayControllerButtons = () => {
+    const dispatch = useDispatch();
     const [playing, setPlaying] = useState(false);
+
+    const toPrevTrack = () => {
+        dispatch(playPrevTrack());
+    }
+
+    const toNextTrack = () => {
+        dispatch(playNextTrack());
+    }
 
     return (
         <Container>
@@ -53,13 +64,13 @@ const PlayControllerButtons = () => {
                 <ShuffleIcon />
             </SubIconWrapper>
             <SkipIconWrapper>
-                <SkipPreviousIcon style={{ fontSize: '35px' }} />
+                <SkipPreviousIcon style={{ fontSize: '35px' }} onClick = { toPrevTrack }/>
             </SkipIconWrapper>
             <PlayIconWrapper onClick={() => setPlaying(!playing)}>
                 {playing ? <PauseIcon style={{ fontSize: '55px' }} /> : <PlayArrowIcon style={{ fontSize: '55px' }} />}
             </PlayIconWrapper>
             <SkipIconWrapper>
-                <SkipNextIcon style={{ fontSize: '35px' }} />
+                <SkipNextIcon style={{ fontSize: '35px' }} onClick = { toNextTrack }/>
             </SkipIconWrapper>
             <SubIconWrapper>
                 <RepeatIcon />

--- a/client/components/organisms/Cards/TrackRowCard/index.tsx
+++ b/client/components/organisms/Cards/TrackRowCard/index.tsx
@@ -56,7 +56,7 @@ const TrackRowCard = ( data : TrackRowCardProps ) => {
     <List>
         <LyricModal src={imageUrl} title={albumTitle} artist={artistName} lyrics={lyrics} visibility = {displayLyrics} onClickFunc = {onClickShowLyric}/>
         <TrackLeft>
-            <CheckBox id={id} />
+            <CheckBox id={id} data={data}/>
             <TrackPlayBtnContainer>
                 <TrackPlayButton data={data} imgVariant="trackRowCard" />
             </TrackPlayBtnContainer>

--- a/client/components/organisms/DetailHeader/index.tsx
+++ b/client/components/organisms/DetailHeader/index.tsx
@@ -1,4 +1,8 @@
+import { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
+
+import { addToUpNext, addToUpNextAndPlay } from 'reducers/musicPlayer';
 
 import Text from '@components/atoms/Text';
 import HeaderButtonGroup from '@components/organisms/HeaderButtonGroup';
@@ -64,6 +68,11 @@ interface DetailHeaderProps {
 }
 
 const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
+    const dispatch = useDispatch();
+    const onAddUpNextHandler = () => {
+        sort === 'track'? dispatch(addToUpNextAndPlay([data])) : dispatch(addToUpNextAndPlay(data.tracks));
+    }
+
     return (
         <HeaderContainter>
             <ImageContainer>
@@ -87,8 +96,8 @@ const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
                     </DescriptionContainer>
                 </TextContainer>
                 <ButtonContainer>
-                    {sort === 'track' && <HeaderButtonGroup sort="track" />}
-                    {sort !== 'track' && <HeaderButtonGroup />}
+                    {sort === 'track' && <HeaderButtonGroup sort="track" onAddUpNextHandler = {onAddUpNextHandler}/>}
+                    {sort !== 'track' && <HeaderButtonGroup onAddUpNextHandler = {onAddUpNextHandler}/>}
                 </ButtonContainer>
             </DetailContainer>
         </HeaderContainter>

--- a/client/components/organisms/DetailHeader/index.tsx
+++ b/client/components/organisms/DetailHeader/index.tsx
@@ -69,7 +69,7 @@ interface DetailHeaderProps {
 
 const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
     const dispatch = useDispatch();
-    const onAddUpNextHandler = () => {
+    const onAddUpNextAndPlayHandler = () => {
         sort === 'track'? dispatch(addToUpNextAndPlay([data])) : dispatch(addToUpNextAndPlay(data.tracks));
     }
 
@@ -96,8 +96,8 @@ const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
                     </DescriptionContainer>
                 </TextContainer>
                 <ButtonContainer>
-                    {sort === 'track' && <HeaderButtonGroup sort="track" onAddUpNextHandler = {onAddUpNextHandler}/>}
-                    {sort !== 'track' && <HeaderButtonGroup onAddUpNextHandler = {onAddUpNextHandler}/>}
+                    {sort === 'track' && <HeaderButtonGroup sort="track" onAddUpNextHandler = {onAddUpNextAndPlayHandler}/>}
+                    {sort !== 'track' && <HeaderButtonGroup onAddUpNextHandler = {onAddUpNextAndPlayHandler}/>}
                 </ButtonContainer>
             </DetailContainer>
         </HeaderContainter>

--- a/client/components/organisms/FloatingSelectMenu/index.tsx
+++ b/client/components/organisms/FloatingSelectMenu/index.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 import CheckBox from '@components/atoms/CheckBox';
 import CloseIcon from '@material-ui/icons/Close';
@@ -10,7 +11,11 @@ import PlaylistPlayIcon from '@material-ui/icons/PlaylistPlay';
 import QueueMusicIcon from '@material-ui/icons/QueueMusic';
 import MusicNoteIcon from '@material-ui/icons/MusicNote';
 
-const Container = styled.div`
+interface ContainerProps {
+    visibility: boolean
+}
+
+const Container = styled.div<ContainerProps>`
     position: fixed;
     top: 0;
     right: 0;
@@ -23,7 +28,7 @@ const Container = styled.div`
     display: flex;
     flex-flow: column;
     align-items: center;
-    visibility: hidden;
+    visibility: ${(props) => props.visibility ? "visible" : "hidden"}
 `;
 
 const SelectAreaContainer = styled.div`
@@ -77,9 +82,11 @@ const PlayButtonContainer = styled.div`
 `;
 
 const FloatingSelectMenu = () => {
-    const [selectedTrackCount, setSelectedTrackCount] = useState(0);
+    const { tracks } = useSelector(state =>  state.selectedTrack);
+    const selectedTrackCount = tracks.length;
+
     return (
-        <Container>
+        <Container visibility={selectedTrackCount !== 0}>
             <SelectAreaContainer>
                 <CheckBoxContainer><CheckBox id= "floatingMenu"/></CheckBoxContainer>
                 <CheckBoxSpan>

--- a/client/components/organisms/FloatingSelectMenu/index.tsx
+++ b/client/components/organisms/FloatingSelectMenu/index.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import { clearAllTracks } from 'reducers/selectedTrack';
+
 import CheckBox from '@components/atoms/CheckBox';
 import CloseIcon from '@material-ui/icons/Close';
 import IconButton from '@components/atoms/IconButton';
@@ -82,8 +84,13 @@ const PlayButtonContainer = styled.div`
 `;
 
 const FloatingSelectMenu = () => {
+    const dispatch = useDispatch();
     const { tracks } = useSelector(state =>  state.selectedTrack);
     const selectedTrackCount = tracks.length;
+
+    const onClickCloseButtonHandler = () => {
+        dispatch(clearAllTracks());
+    }
 
     return (
         <Container visibility={selectedTrackCount !== 0}>
@@ -96,7 +103,7 @@ const FloatingSelectMenu = () => {
                     {selectedTrackCount}곡 선택
                 </SelectedTrackCounter>
                 <CloseButtonContainer>
-                    <IconButton variant="plainBlackRegular" icon={CloseIcon} />
+                    <IconButton variant="plainBlackRegular" icon={CloseIcon} onClick={onClickCloseButtonHandler}/>
                 </CloseButtonContainer>
             </SelectAreaContainer>
             <ButttonAreaContainer>

--- a/client/components/organisms/FloatingSelectMenu/index.tsx
+++ b/client/components/organisms/FloatingSelectMenu/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { clearAllTracks } from 'reducers/selectedTrack';
+import { addToUpNext, addToUpNextAndPlay } from 'reducers/musicPlayer';
 
 import CheckBox from '@components/atoms/CheckBox';
 import CloseIcon from '@material-ui/icons/Close';
@@ -88,6 +89,14 @@ const FloatingSelectMenu = () => {
     const { tracks } = useSelector(state =>  state.selectedTrack);
     const selectedTrackCount = tracks.length;
 
+    const onAddUpNextAndPlayHandler = () => {
+        dispatch(addToUpNextAndPlay(tracks));
+    }
+
+    const onAddUpNextHandler = () => {
+        dispatch(addToUpNext(tracks));
+    }
+
     const onClickCloseButtonHandler = () => {
         dispatch(clearAllTracks());
     }
@@ -107,11 +116,16 @@ const FloatingSelectMenu = () => {
                 </CloseButtonContainer>
             </SelectAreaContainer>
             <ButttonAreaContainer>
-                <Button variant="secondary" height="40" icon={PlaylistPlayIcon}>현재재생목록에 추가</Button>
+                <Button variant="secondary" height="40" icon={PlaylistPlayIcon} onClick = {onAddUpNextHandler}>현재재생목록에 추가</Button>
                 <Button variant="secondary" height="40" icon={QueueMusicIcon}>추가</Button>
                 <Button variant="secondary" height="40" icon={MusicNoteIcon}>MP3 구매</Button>
                 <PlayButtonContainer>
-                    <Button variant="primary" width="120" height="40" icon={PlayArrowIcon}>재생</Button>
+                    <Button 
+                    variant="primary" 
+                    width="120" 
+                    height="40" 
+                    icon={PlayArrowIcon}
+                    onClick={onAddUpNextAndPlayHandler}>재생</Button>
                 </PlayButtonContainer>
             </ButttonAreaContainer>
         </Container>

--- a/client/components/organisms/HeaderButtonGroup/index.tsx
+++ b/client/components/organisms/HeaderButtonGroup/index.tsx
@@ -43,16 +43,17 @@ const contentsDropDownMenu = [{
 }];
 
 interface HeaderButtonGroupProps {
-    sort?: 'track'
+    sort?: 'track';
+    onAddUpNextHandler: any;
 }
 
-const HeaderButtonGroup = ({sort}: HeaderButtonGroupProps) => {
+const HeaderButtonGroup = ({sort, onAddUpNextHandler}: HeaderButtonGroupProps) => {
     return (
         <ButtonContainer sort={sort}>
             { sort === 'track' && 
-            <Button variant = "primary" width='100' height='40' icon={PlayArrowIcon} >재생</Button> }
+            <Button variant = "primary" width='100' height='40' icon={PlayArrowIcon} onClick={onAddUpNextHandler}>재생</Button> }
             { sort !== 'track' && 
-            <Button variant = "primary" width='130' height='40' icon={PlayArrowIcon} >전체재생</Button>}
+            <Button variant = "primary" width='130' height='40' icon={PlayArrowIcon} onClick={onAddUpNextHandler}>전체재생</Button>}
             { sort !== 'track' && 
             <Button width='130' height='40' icon={ShuffleIcon}>랜덤재생</Button>
             }

--- a/client/components/organisms/MusicPlayer/PlayController/index.tsx
+++ b/client/components/organisms/MusicPlayer/PlayController/index.tsx
@@ -6,7 +6,6 @@ import VolumnController from '@components/molecules/VolumnController';
 import PlaylistDisplayButton from '@components/molecules/PlaylistDisplayButton';
 import ProgressBar from '@components/molecules/ProgressBar';
 import PlayerTrackInfo from '@components/organisms/MusicPlayer/PlayerTrackInfo';
-import { playPrevTrack, playNextTrack } from 'reducers/musicPlayer';
 import { useSelector, useDispatch } from 'react-redux';
 
 const Container = styled.div`

--- a/client/components/organisms/MusicPlayer/PlayController/index.tsx
+++ b/client/components/organisms/MusicPlayer/PlayController/index.tsx
@@ -6,6 +6,8 @@ import VolumnController from '@components/molecules/VolumnController';
 import PlaylistDisplayButton from '@components/molecules/PlaylistDisplayButton';
 import ProgressBar from '@components/molecules/ProgressBar';
 import PlayerTrackInfo from '@components/organisms/MusicPlayer/PlayerTrackInfo';
+import { playPrevTrack, playNextTrack } from 'reducers/musicPlayer';
+import { useSelector, useDispatch } from 'react-redux';
 
 const Container = styled.div`
     position: fixed;
@@ -72,6 +74,8 @@ interface PlayControllerProps {
 
 const PlayController = ({track, displayHeader, displayHeaderHandler}: PlayControllerProps) => {
     const data = track;
+    const dispatch = useDispatch();
+    const { nowPlaying, playTime, upNextTracks } = useSelector(state => state.musicPlayer);
     return (
         <Container>
             <ProgresBarContainer>
@@ -85,7 +89,7 @@ const PlayController = ({track, displayHeader, displayHeaderHandler}: PlayContro
                     <PlayControllerButtons />
                 </PlayButtonsContainer>
                 <PlaytimeContainer>
-                    <Playtime current={100} total={ data.playtime } />
+                    <Playtime current={playTime} total={ data.playtime } />
                 </PlaytimeContainer>
                 <VolumnControllerContainer>
                     <VolumnController />

--- a/client/components/organisms/MusicPlayer/index.tsx
+++ b/client/components/organisms/MusicPlayer/index.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
 import PlayerTrackList from '@components/organisms/CardLists/PlayerTrackList';
 import PlayController from '@components/organisms/MusicPlayer/PlayController';
 
-import { contentType } from '@constants/identifier';
-import ComponentInfoWrapper from '@utils/context/ComponentInfoWrapper';
+import { contentType } from 'constants/identifier';
+import ComponentInfoWrapper from 'utils/context/ComponentInfoWrapper';
 
 interface MusicPlayerProps {
     tracks;
@@ -84,8 +85,9 @@ const ControllerContainer = styled.div`
     z-index: 500;
 `;
 
-const MusicPlayer = ({ tracks }: MusicPlayerProps) => {
-    const [nowPlaying, setNowPlaying] = useState(tracks[0]);
+const MusicPlayer = () => {
+    const dispatch = useDispatch();
+    const { nowPlaying, playTime, upNextTracks } = useSelector(state => state.musicPlayer);
     const [displayHeader, setDisplayHeader] = useState(false);
 
     const displayHeaderHandler = () => {
@@ -102,7 +104,7 @@ const MusicPlayer = ({ tracks }: MusicPlayerProps) => {
                     <TrackListContainer>
                         <TrackHeaderContainer>이어지는 노래</TrackHeaderContainer>
                         <TrackContainer>
-                            <PlayerTrackList items={tracks} />
+                            <PlayerTrackList items={upNextTracks} />
                         </TrackContainer>
                     </TrackListContainer>
                 </HeaderContainer>

--- a/client/pages/artist/[id].tsx
+++ b/client/pages/artist/[id].tsx
@@ -55,7 +55,6 @@ const Artist = ({ artistData, trackData }) => {
                     <ComponentInfoWrapper componentId={contentType.track}>
                         {trackData && trackData.length > 0 ? (
                             <>
-                                <ContentsButtonGroup />
                                 <TrackListContainer>
                                     <TrackRowList items={trackData} />
                                 </TrackListContainer>

--- a/client/reducers/index.ts
+++ b/client/reducers/index.ts
@@ -1,6 +1,8 @@
 import { HYDRATE } from 'next-redux-wrapper';
 import { combineReducers } from 'redux';
 import user from './user';
+import selectedTrack from './selectedTrack';
+import musicPlayer from './musicPlayer';
 
 // (아전상태, 액션) => 다음상태
 const rootReducer = combineReducers({
@@ -18,6 +20,8 @@ const rootReducer = combineReducers({
         }
     },
     user,
+    selectedTrack,
+    musicPlayer
 });
 
 export default rootReducer;

--- a/client/reducers/musicPlayer.ts
+++ b/client/reducers/musicPlayer.ts
@@ -175,6 +175,20 @@ export const playPrevTrack = () => {
     }
 }
 
+export const addToUpNext = (data) => {
+    return {
+        type: 'ADD_TO_UPNEXT',
+        data
+    }
+}
+
+export const addToUpNextAndPlay = (data) => {
+    return {
+        type: 'ADD_TO_UPNEXT_AND_PLAY',
+        data
+    }
+}
+
 const getNextTrack = (state) => {
     const nowPlayingIdx = state.upNextTracks.findIndex(t => t.id === state.nowPlaying.id);
     const nextTrackIdx = nowPlayingIdx === state.upNextTracks.length - 1 ? nowPlayingIdx : nowPlayingIdx + 1;
@@ -202,6 +216,17 @@ const reducer = (state: MusicPlayer = initialState, action) => {
                 ...state,
                 playTime: 0,
                 nowPlaying: prevTrack
+            }
+        case 'ADD_TO_UPNEXT':
+            return {
+                ...state,
+                upNextTracks: [...state.upNextTracks, ...action.data],
+            }
+        case 'ADD_TO_UPNEXT_AND_PLAY':
+            return {
+                upNextTracks: [...state.upNextTracks, ...action.data],
+                playTime: 0,
+                nowPlaying: action.data[0]
             }
         default: 
             return state;

--- a/client/reducers/musicPlayer.ts
+++ b/client/reducers/musicPlayer.ts
@@ -1,9 +1,208 @@
-export const initialState = {
+import { TrackRowCardProps } from 'interfaces/props';
 
+interface MusicPlayer {
+    nowPlaying: TrackRowCardProps;
+    playTime: number;
+    upNextTracks: TrackRowCardProps[];
 }
 
-const reducer = (state = initialState, action) => {
+const initialState = {
+    upNextTracks: [{
+        "id": 5,
+        "title": "Lovesick Girls",
+        "lyrics": "영원한 밤\n창문 없는 방에 우릴 가둔 love\nWhat can we say\n매번 아파도 외치는 love\n\n다치고 망가져도 나\n뭘 믿고 버티는 거야\n어차피 떠나면 상처투성인 채로 미워하게 될걸\n끝장을 보기 전 끝낼 순 없어\n이 아픔을 기다린 것처럼\n\n아마 다 잠깐 일지도 몰라\n우린 무얼 찾아서 헤매는 걸까\n\nBut I don’t care I’ll do it over and over\n내 세상 속엔 너만 있으면 돼\n\nWe are the lovesick girls\n네 멋대로 내 사랑을 끝낼순 없어\nWe are the lovesick girls\n이 아픔 없인 난 아무 의미가 없어\n\nBut we were born to be alone\nYeah we were born to be alone\nYeah we were born to be alone \nBut why we still looking for love\n\nNo love letters, no x and o’s\nNo love never, my exes know\nNo diamond rings, that set in stone\nTo the left, better left alone\n\nDidn’t wanna be a princess, I’m priceless\nA prince not even on my list\nLove is a drug that I quit\nNo doctor could help when I’m lovesick",
+        "playtime": 192,
+        "albumId": 9,
+        "album": {
+            "id": 9,
+            "title": "THE ALBUM",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/004/983/4983288.jpg?type=r360Fll&v=20201106182509"
+        },
+        "artist": {
+            "id": 4,
+            "name": "BLACKPINK"
+        },
+        "liked": 0
+    },
+    {
+        "id": 1,
+        "title": "Square",
+        "lyrics": "All the colors and personalities\n모든 색깔과 성격들 \nyou can’t see right through what I truly am\n그것들 사이로는 내가 정말 어떤 사람인지 볼 수 없어\nyou’re hurting me without noticing \n넌 예고도 없이 나에게 상처를 주고 \nI’m so, so broke like someone just robbed me\n누가 날 털어간 것 마냥 부서진 것 같아\n\nI’m no invincible\n난 강한 사람이 아니야\nI have much memories of getting more weaker \n난 점점 약해져가는 기억들이 훨씬 많은 걸\nI know I’m not loveable\n나도 내가 사랑받을 수 없는 거 알아\nbut you know what you’d have to say\n그래도 네가 어떤 말을 해줘야 하는지 알지?\n\n\n“Come on let’s go to bed \n“나와 같이 침대로 가자 \nwe gonna rock the night away\n우린 이 밤을 신나게 보낼 거야\nwho did that to you, babe\n누가 너에게 그런 짓을 한 거야\nIf you’re not in the right mood to sleep now then, \n네가 당장 잠들 수 있는 기분이 아니라면 \nCome on, let’s drink and have very unmanageable day \n나와서 나랑 한잔하고, 감당하기 힘든 하루를 보내자!\nwould you want me in bae\n내가 거기 있길 바라?\nIf you’re not in the right mood to sleep now then \n네가 당장 잠들 수 있는 기분이 아니라면 \ncome take my arms and go \n나와 함께 가자!\nI’II be yours for sure”\n내가 너의 것이 되어줄게!” ",
+        "playtime": 261,
+        "albumId": 10,
+        "album": {
+            "id": 10,
+            "title": "Every letter I sent you.",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+        },
+        "artist": {
+            "id": 5,
+            "name": "백예린"
+        },
+        "liked": 0
+    },
+    {
+        "id": 2,
+        "title": "Popo (How deep is our love?)",
+        "lyrics": "Get away from your own sorrow\n슬픔에서 벗어나봐요\nLet the sun come through your window\n당신의 창문에 햇살이 들어오게 해봐요\nYou don’t have to open up wide \n마음을 활짝 열 필요는 없지만\nBut I want to intimate\n전 가까워지고 싶어요 \n\n\nYou’ll never know how much your voice attracts me, boy\n당신은 당신 목소리가 날 얼마나 끌리게 하는지 모를 거예요\nIt’s exceptional\n정말 특별해요\nEspecially, when you’re playing the song for me\n특히 날 위해 곡을 연주할 땐\nI can’t take my eyes away\n눈을 뗄 수 없어요\n\n\nCan I walk with you? \n당신과 걸을 수 있을까요\nor have a tea with you\n차를 마셔도 좋아요\nYour scent makes me feel like I live in Paris \n당신의 향기는 내가 마치 파리에 살고 있는 것처럼 느끼게 해요\nCan I love you?\n사랑해도 될까요?\ngiving my all to you?\n내 전부를 다 주는 것도요 \nyou \n당신에게요",
+        "playtime": 261,
+        "albumId": 10,
+        "album": {
+            "id": 10,
+            "title": "Every letter I sent you.",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+        },
+        "artist": {
+            "id": 5,
+            "name": "백예린"
+        },
+        "liked": 0
+    },
+    {
+        "id": 3,
+        "title": "0310",
+        "lyrics": "You smoked and you looked at me\n넌 담배를 피며 날 쳐다봤어\nI hate it when you do \n난 네가 그럴 때가 싫더라\nI said “no thanks” to you\n난 됐다고 말했고 \nyou asked me If I was okay,\n넌 괜찮냐 물었지 \nwhat If I wasn’t \n안 괜찮다면 뭐 어때 \n\nLeaving is fine \n떠나도 괜찮아\nIt’s just I don’t wanna be all by myself again\n난 그냥 또 다시 혼자가 되고 싶지 않은데\nlike every time, like every last time\n항상 그랬듯, 항상 그전처럼 말야\n\nYou knew that I was no good for you \n넌 내가 너에게 좋지 않을 거란 걸 알았어\nwhen we lay down after doing that things you loved \n네가 좋아하던 것들을 하고나서 누워있을 때 말야 \nyou knew that I wasn’t better than you \n넌 내가 너보다 나은 사람이 아닌 걸 알고 있었어 \nI hope that I could be seemed really fine with you leaving \n네가 떠나도 괜찮아 보일 수 있으면 좋겠어",
+        "playtime": 250,
+        "albumId": 10,
+        "album": {
+            "id": 10,
+            "title": "Every letter I sent you.",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/735/3735168.jpg?type=r360Fll&v=20200218131210"
+        },
+        "artist": {
+            "id": 5,
+            "name": "백예린"
+        },
+        "liked": 0
+    },
+    {
+        "id": 4,
+        "title": "그냥",
+        "lyrics": "keep callin' to me\n왜 인지는 묻지 말아 주면은 안돼?\njust text me \n밥은 잘 먹고 있는지에 대해\n뭔들 난 다 좋아\n별거 없는 그런 삶\nim so sick of these days\n말해 줘 너의 밤은 어때\n또 너의 날은 어떻고?\n나의 시간은 못 돼서\n다시 이 굴레에 날 가둬  \n이 밤은 또 내껄\n자꾸만 뺏으려 들어\nwhere should i go right now? \n\n뭘 쥐어도 다 모래\n결국 흐르니 난 뭘 해?  \n못 된 생각이 인내를 놓을땐 \n도태 되는거야 no thanks\n가지면 뭐해\ni got nothing to prove no\n사랑을 할래\n위기는 모르는 채로 oh \n너 불안정한 내게\n자꾸 깊은 믿음을 심어주지마\n나도 모르는 새에\n널 내 안에 들여놓고 착각 할지도 몰라\n\npainful thoughts \nin ma head \n다 모순인 거야\n비운의 틈새로\n나 겨울의 냄새를 맡고파\npainful thoughts\nim ma head \n다 거짓인 거야\n난 그저 여름의 향수에만 잠깐 젖고파\ncuz im bored\n아늑하기만 한\n나의 방은 어두워서\n상처는 아물지  않아\n날 봐줘\n저 멀리 가고 있는\n날 보게 된다면은 붙잡아줘 ",
+        "playtime": 217,
+        "albumId": 11,
+        "album": {
+            "id": 11,
+            "title": "그냥",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg"
+        },
+        "artist": {
+            "id": 3,
+            "name": "이영지"
+        },
+        "liked": 0
+    },
+    {
+        "id": 6,
+        "title": "암실",
+        "lyrics": "농도가 아주 짙은\n랩을 뱉어도\n네 안에 쌓인 독\n덜어 낼 수 없어\n팔리는 음악은\n누가 찍어\n모자란 걸\n양심을 잃은 돈 거머쥘 수 없어\n\n더 벌어서\n더 버려 벗겨지는 마음\n개나 준 채로 숨어 암전 속으로\n나 바뻐\n좌절도 늘 그랬듯이 힘이 쭉 빠져\n밉상이니 맘껏 비웃어\n\n난 찾아야 돼 exit 작업실 의자 뒤에\n문 말고 딜레마 속 지랄맞은 굴레 i mean\n지피지기 면백전 백승 은 나발이고\n다물어 이 방 안에 내 적은 나뿐임\nuh 나는 나를 알아 점점 퇴보해 가\n구멍난 스타킹 안 꿰매 신어도 되는데\n나 왜이리 빈곤한 걸까\n묻지 말아줘 맘이 공허한 걸까\n\n아직 잃을 준비가 안 된 것 같아서 좀 많이 두려워\n돈 명예 시계 전부 얻어도 날 다 채울 수 가 없으니\n더 날 불러줘 막연한 회의감 가득한 방 안에서도 듣게끔\n\nplease 날 나가게 해줘\n좀 더 잃을 게 많아져도\ni can't do this no more\nso please 날 나가게 해줘\n날 지워낸 다음 덮어내 다시\nblack 을 제외한 색깔로 more\nso please 날 나가게\n날아가게 해줘\nso please 날 나가게\n날아가게 해줘\nso please 날 나가게\n날아가게 해줘\nso please 날 나가게\n날아가게 해줘",
+        "playtime": 152,
+        "albumId": 12,
+        "album": {
+            "id": 12,
+            "title": "암실",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/003/399/3399784.jpg"
+        },
+        "artist": {
+            "id": 3,
+            "name": "이영지"
+        },
+        "liked": 0
+    },
+    {
+        "id": 7,
+        "title": "Only One",
+        "lyrics": "멀어져만 가는 그대 You’re the only one \r\n내가 사랑했던 것만큼 You’re the only one \r\n아프고 아프지만 바보 같지만 Good bye \r\n다시 널 못 본다 해도 You’re the only one \r\nOnly One \r\n\r\n어색하게 마주앉아 사소한 얘기로 안부를 묻고 \r\n가끔 대화가 끊기는 순간에는 \r\n차가운 정적 우릴 얼게 만들어 \r\n\r\n지금 이 자리에서 우리는 남이 되겠지 \r\n어느 누군가는 눈물 흘리며 남겠지만 \r\n상처 주지 않으려고 자꾸 애를 써가면서 \r\n눈치 보는 니 모습 싫어 So I’ll let you go \r\n\r\n내 사랑 이제는 안녕 You’re the only one (You’re the only one) \r\n이별하는 이 순간에도 You’re the only one \r\n아프고 아프지만 바보 같지만 Good bye \r\n다시 널 못 본다 해도 You’re the only one \r\nOnly One \r\nYou’re the only one, Only One\r\n\r\n(only one,only one)\r\n\r\n갑작스런 나의 말에 왠지 모르게 넌 안심한듯 해 \r\n어디서부터 우린 이렇게 잘못된 걸까 \r\n오래 전부터 다른 곳만 기대한 건 아닌지 \r\n\r\n너무 다른 시작과 끝의 그 날카로움이 \r\n내 심장을 찌르는 아픔은 왜 똑같은지 \r\n벅찬 가슴이 한 순간에 공허하게 무너져서 \r\n이런 내 모습 어떻게 일어설까 \r\n\r\n내 사랑 이제는 안녕 You’re the only one (Only One) \r\n이별하는 이 순간에도 You’re the only one \r\n아프고 아프지만 바보 같지만 Good bye (Good bye) \r\n다시 널 못 본다 해도 You’re the only one (You’re the only one) \r\n\r\n내 머릿속은 언제쯤 너를 지울까 (I will let you go) \r\n하루 이틀 한달, 멀게는 아마 몇 년쯤 (My baby can't forget) \r\n그리고 언젠가 너의 기억 속에는 \r\n나란 사람은 더 이상 살지 않겠지 지우겠지 \r\n\r\nOnly One, Only One \r\nYou’re the only one, Only One",
+        "playtime": 217,
+        "albumId": 13,
+        "album": {
+            "id": 13,
+            "title": "Only One",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/000/326/326356.jpg?type=r480Fll&v=20201113025511"
+        },
+        "artist": {
+            "id": 7,
+            "name": "보아"
+        },
+        "liked": 0
+    },
+    {
+        "id": 8,
+        "title": "Not Over U",
+        "lyrics": "Take me away 손목에 채워진 시계를 봐\r\n여느 때와 다름없이 긴 침묵은 또 날 찾아와\r\n저기 오는 기차가 내 앞을 지나가고\r\n지금이 또 지나면 다음이 올 거란 믿음에 난 살아\r\n \r\n하루의 절반 눈을 뜨면 어제처럼 혼자 걷는 길\r\n그건 별거 아냐 단지 혼자 기억을\r\n걷다 널 만나는 일 난 두려워\r\n \r\nOh (Oh) 이렇게 나만큼 아픈 거니\r\n먼저 날 돌아보면 안 되니\r\n너와는 반대로 서 있지만 I'm not over you\r\n \r\n앞서 걷는 그림자가 내게 손짓하며\r\n저 좁은 길모퉁이 그곳으로 날 데려가고 (난 따라나서)\r\n눈에 선한 두 사람이 아직 저기 보여\r\n누구보다 아름다운 모습은 꽤 행복해 보여\r\n \r\n하루의 절반 눈을 뜨면 어제처럼 혼자 걷는 길 \r\n그건 별거 아냐 단지 혼자 기억을 \r\n걷다 널 만나는 일 난 두려워\r\n \r\nOh (Oh) 이렇게 나만큼 아픈 거니\r\n먼저 날 돌아보면 안 되니\r\n너와는 반대로 서 있지만 I'm not over you\r\n \r\nOh (Oh) 이 시간을 돌릴 수 있다면\r\n너와 난 기억을 나누지도\r\n반대로 걷지도 않았겠지 I'm not over you \r\n \r\nOh Oh Oh Oh Oh 내 곁에 넌 없지만\r\nOh Oh Oh Oh Oh 여전히 넌 내 안에 있어\r\nOh Oh Oh Oh Oh 오늘도 하늘은 맑은데\r\nOh Oh Oh Oh Oh 내 눈에 비가 내려 Oh\r\n\r\n기억은 참 슬퍼 이젠 지금이 아닌\r\n지난 시간이라고 날 알게 해\r\n \r\nOh (Oh) 이렇게 나만큼 아픈 거니\r\n먼저 날 돌아보면 안 되니\r\n너와는 반대로 서 있지만 I'm not over you\r\n \r\nOh (Oh) 이 시간을 돌릴 수 있다면\r\n너와 난 기억을 나누지도\r\n반대로 걷지도 않았겠지 I'm not over you ",
+        "playtime": 180,
+        "albumId": 13,
+        "album": {
+            "id": 13,
+            "title": "Only One",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/000/326/326356.jpg?type=r480Fll&v=20201113025511"
+        },
+        "artist": {
+            "id": 7,
+            "name": "보아"
+        },
+        "liked": 1
+    }],
+    nowPlaying: {
+        "id": 5,
+        "title": "Lovesick Girls",
+        "lyrics": "영원한 밤\n창문 없는 방에 우릴 가둔 love\nWhat can we say\n매번 아파도 외치는 love\n\n다치고 망가져도 나\n뭘 믿고 버티는 거야\n어차피 떠나면 상처투성인 채로 미워하게 될걸\n끝장을 보기 전 끝낼 순 없어\n이 아픔을 기다린 것처럼\n\n아마 다 잠깐 일지도 몰라\n우린 무얼 찾아서 헤매는 걸까\n\nBut I don’t care I’ll do it over and over\n내 세상 속엔 너만 있으면 돼\n\nWe are the lovesick girls\n네 멋대로 내 사랑을 끝낼순 없어\nWe are the lovesick girls\n이 아픔 없인 난 아무 의미가 없어\n\nBut we were born to be alone\nYeah we were born to be alone\nYeah we were born to be alone \nBut why we still looking for love\n\nNo love letters, no x and o’s\nNo love never, my exes know\nNo diamond rings, that set in stone\nTo the left, better left alone\n\nDidn’t wanna be a princess, I’m priceless\nA prince not even on my list\nLove is a drug that I quit\nNo doctor could help when I’m lovesick",
+        "playtime": 192,
+        "albumId": 9,
+        "album": {
+            "id": 9,
+            "title": "THE ALBUM",
+            "imageUrl": "https://musicmeta-phinf.pstatic.net/album/004/983/4983288.jpg?type=r360Fll&v=20201106182509"
+        },
+        "artist": {
+            "id": 4,
+            "name": "BLACKPINK"
+        },
+        "liked": 0
+    },
+    playTime: 0
+}
+
+export const playNextTrack = () => {
+    return {
+        type: 'PLAY_NEXT_TRACK',
+    }
+}
+
+export const playPrevTrack = () => {
+    return {
+        type: 'PLAY_PREV_TRACK',
+    }
+}
+
+const getNextTrack = (state) => {
+    const nowPlayingIdx = state.upNextTracks.findIndex(t => t.id === state.nowPlaying.id);
+    const nextTrackIdx = nowPlayingIdx === state.upNextTracks.length - 1 ? nowPlayingIdx : nowPlayingIdx + 1;
+    return state.upNextTracks[nextTrackIdx];
+}
+
+const getPrevTrack = (state) => {
+    const nowPlayingIdx = state.upNextTracks.findIndex(t => t.id === state.nowPlaying.id);
+    const prevTrackIdx = nowPlayingIdx == 0 ? nowPlayingIdx : nowPlayingIdx - 1;
+    return state.upNextTracks[prevTrackIdx];
+}
+
+const reducer = (state: MusicPlayer = initialState, action) => {
     switch (action.type) {
+        case 'PLAY_NEXT_TRACK':
+            const nextTrack = getNextTrack(state);
+            return {
+                ...state,
+                playTime: 0,
+                nowPlaying: nextTrack
+            }
+        case 'PLAY_PREV_TRACK':
+            const prevTrack = getPrevTrack(state);
+            return {
+                ...state,
+                playTime: 0,
+                nowPlaying: prevTrack
+            }
         default: 
             return state;
     }

--- a/client/reducers/selectedTrack.ts
+++ b/client/reducers/selectedTrack.ts
@@ -22,6 +22,12 @@ export const unselectTrack = (id: number) => {
     }
 }
 
+export const clearAllTracks = () => {
+    return {
+        type: 'CLEAR_All_TRACKS'
+    }
+}
+
 const reducer = (state: SelectedTrack = initialState, action) => {
     switch (action.type) {
         case 'SELECT_TRACK':
@@ -32,6 +38,10 @@ const reducer = (state: SelectedTrack = initialState, action) => {
             const updatedTracks = state.tracks.filter(e => e.id !== action.id);
             return {
                 tracks: updatedTracks
+            }
+        case 'CLEAR_All_TRACKS':
+            return {
+                tracks: []
             }
         default: 
             return state;

--- a/client/reducers/selectedTrack.ts
+++ b/client/reducers/selectedTrack.ts
@@ -1,0 +1,41 @@
+import { TrackRowCardProps } from 'interfaces/props';
+
+interface SelectedTrack {
+    tracks: TrackRowCardProps[]
+}
+
+const initialState = {
+    tracks: []
+}
+
+export const selectTrack = (data: TrackRowCardProps) => {
+    return {
+        type: 'SELECT_TRACK',
+        data
+    }
+}
+
+export const unselectTrack = (id: number) => {
+    return {
+        type: 'UNSELECT_TRACK',
+         id
+    }
+}
+
+const reducer = (state: SelectedTrack = initialState, action) => {
+    switch (action.type) {
+        case 'SELECT_TRACK':
+            return {
+                tracks: [...state.tracks, action.data]
+            }
+        case 'UNSELECT_TRACK':
+            const updatedTracks = state.tracks.filter(e => e.id !== action.id);
+            return {
+                tracks: updatedTracks
+            }
+        default: 
+            return state;
+    }
+}
+
+export default reducer;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -25,6 +25,7 @@
       "@utils/*":["utils/*"],
       "@constants/*":["constants/*"],
       "@hooks/*":["hooks/*"],
+      "@reducers/*":["reducers/*"],
       "@stores/*":["stores/*"],
       "@interfaces/*":["interfaces/*"]
     }


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 1 플로팅 셀렉트 메뉴에서 현재재생목록에 추가 & 재생 기능 구현

![Dec-11-2020 03-00-14](https://user-images.githubusercontent.com/48787170/101811287-41fc8e80-3b5d-11eb-9895-fed6de631464.gif)

- [x] 작업 내역 2 앨범 및 플레이리스트 상세 페이지에서 전체 재생 기능 구현
![Dec-11-2020 03-01-25](https://user-images.githubusercontent.com/48787170/101811296-45901580-3b5d-11eb-8c7e-308f29f3a1a0.gif)

- [x] 작업 내역 3 사용되지 않는 컴포넌트와 import 삭제
- [ ] 작업 내역 4


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 보관함-노래 에서 upnext로 추가하기 위해서는 응답 구조를 바꿔야 할 것 같습니다..
```
       {     "id": 8,
            "title",
            "lyrics",
            "playtime",
            "albumId",
            "album": {
                "id",
                "title",
                "imageUrl"
            },
            "artist": {
                "id"
                "name"
            },
            "liked" }
```

이렇게 모든 정보를 다 가지고 와야 할 것 같습니다
- 특이 사항 2 아래의 동그란 버튼을 눌러서 업넥스트에 추가하는 기능을 만들기 위해서는 어쩔 수 없이 통신을 한 번 더 해야 할 것 같습니다
<img width="60" alt="스크린샷 2020-12-11 오전 3 03 48" src="https://user-images.githubusercontent.com/48787170/101811497-7f611c00-3b5d-11eb-965c-dd07b3e9af5c.png">

- 특이 사항 3 마찬가지로 기능에 대해서는 움짤 확인해주세요
- 특이 사항 4 오늘 허리가 너무 아파서 작업을 생각보다 많이 못했네요ㅜㅜ 내일 또 병원 갈 수도 있을 것 같은데 최대한 빨리 기능구현 하겠습니다

<br/><br/>
