### PR TITLE
[FE] 화면 전환 이벤트 수집

### DIFF
--- a/client/hooks/useClickEventLog.ts
+++ b/client/hooks/useClickEventLog.ts
@@ -9,8 +9,8 @@ function useClickEventLog({ userId, href }) {
     const router = useRouter();
 
     const handleClick = () => {
-        eventLogger('click', {
-            userId: handleClick,
+        eventLogger('Click', {
+            userId,
             page: router.asPath,
             targetPage: href,
             ...componentInfo,

--- a/client/hooks/useTransitionEventLog.ts
+++ b/client/hooks/useTransitionEventLog.ts
@@ -10,7 +10,7 @@ function useClickEventLog({ userId }) {
         eventLogger('Transition', {
             userId,
             // page: router.asPath,
-            targetPage: url,
+            page: url,
         });
     };
 

--- a/client/hooks/useTransitionEventLog.ts
+++ b/client/hooks/useTransitionEventLog.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+import eventLogger from '@utils/eventLogger';
+
+function useClickEventLog({ userId }) {
+    const router = useRouter();
+
+    const handleRouteChange = (url) => {
+        eventLogger('Transition', {
+            userId,
+            // page: router.asPath,
+            targetPage: url,
+        });
+    };
+
+    useEffect(() => {
+        router.events.on('routeChangeComplete', handleRouteChange);
+
+        return () => {
+            router.events.off('routeChangeComplete', handleRouteChange);
+        };
+    }, []);
+}
+
+export default useClickEventLog;

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Head from 'next/head'; //head를 수정할 수 있게 함
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
 
 import wrapper from '../store/configureStore';
 import withReduxSaga from 'next-redux-saga';
@@ -14,15 +15,11 @@ import '../assets/global.css';
 
 import { componentType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
+import useTransitionEventLog from '@hooks/useTransitionEventLog';
 
 const Container = styled.div`
     background-color: white;
 `;
-
-const userData = {
-    id: '0',
-    name: 'testUser',
-};
 
 const trackData = {
     id: 3,
@@ -46,6 +43,10 @@ const trackData = {
 const currentPlayList = Array(30).fill(trackData);
 
 const App = ({ Component, pageProps }) => {
+    const user = useSelector((state) => state.user);
+
+    useTransitionEventLog({ userId: user.id });
+
     useEffect(() => {
         // Remove the server-side injected CSS.
         const jssStyles = document.querySelector('#jss-server-side');
@@ -62,7 +63,7 @@ const App = ({ Component, pageProps }) => {
                 <link rel="shortcut icon" href="https://img.icons8.com/cute-clipart/64/000000/like.png" />
             </Head>
             <ComponentInfoContext.Provider value={{ componentId: componentType.mainHeader }}>
-                <HeaderSideBar user={userData} />
+                <HeaderSideBar user={user} />
             </ComponentInfoContext.Provider>
             <ComponentInfoContext.Provider value={{ componentId: componentType.floatingSelectMenu }}>
                 <FloatingSelectMenu />

--- a/client/utils/apis.js
+++ b/client/utils/apis.js
@@ -16,6 +16,6 @@ export const request = async (url, option) => {
         return data.data;
     } catch (err) {
         // TODO : error handling
-        console.log(error);
+        console.log(err);
     }
 };


### PR DESCRIPTION
### 📕 Issue Number

Close #370 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 화면 전환 이벤트 수집 hook 구현, app에 적용


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
```
 eventLogger('Transition', {
            userId,
            // page: router.asPath,
            page: url,
        });
```
이전 상태 url을 조회하기 위해 router.pathname을 사용했을 때는 param 정보 안보이는 문제(/track/[id]와 같이 나옴), asPath를 사용했을 때는 이전 url을 제대로 인식 못함(특히 상세 페이지의 경우). 따라서 현재 상황에서는 iOS 분들 처럼 바뀐 페이지만 저장하도록 했습니다. 

<br/><br/>
