### PR TITLE
[iOS] 이슈번호에 해당하는 이벤트 수집, 저장, 출력 #380 #381 #382

### DIFF
--- a/MiniVibe/MiniVibe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MiniVibe/MiniVibe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
+        "state": {
+          "branch": null,
+          "revision": "2a10bf41da75599a9f8e872dbd44fe0155a2e00c",
+          "version": "5.15.8"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/MiniVibe/MiniVibe/EventLogger/EventLogger.swift
+++ b/MiniVibe/MiniVibe/EventLogger/EventLogger.swift
@@ -34,7 +34,9 @@ final class EventLogger: ObservableObject {
                Search.fetchRequest(),
                Like.fetchRequest(),
                Subscribe.fetchRequest(),
-               MoveTrack.fetchRequest()]
+               MoveTrack.fetchRequest(),
+               Engagement.fetchRequest()
+            ]
         
         let deleteRequests: [NSBatchDeleteRequest]
             = fetchRequsts.map { NSBatchDeleteRequest(fetchRequest: $0) }
@@ -59,7 +61,10 @@ final class EventLogger: ObservableObject {
         let moveTrackLogs = (try? persistentContainer.viewContext
                                 .fetch(MoveTrack.fetchRequest()) as? [EventPrintable]) ?? []
         
-        return (transitions + searchLogs + likeLogs + subscribeLogs + moveTrackLogs)
+        let engagementLogs = (try? persistentContainer.viewContext
+                                .fetch(Engagement.fetchRequest()) as? [EventPrintable]) ?? []
+        
+        return (transitions + searchLogs + likeLogs + subscribeLogs + moveTrackLogs + engagementLogs)
             .sorted { $0.timestamp > $1.timestamp }
     }
 }

--- a/MiniVibe/MiniVibe/EventLogger/Events/EngagementLog.swift
+++ b/MiniVibe/MiniVibe/EventLogger/Events/EngagementLog.swift
@@ -22,7 +22,7 @@ extension EngagementLogType {
     }
 }
 
-struct Active: EngagementLogType {
+struct Foreground: EngagementLogType {
     let userId: Int
     let timestamp = Date()
 }

--- a/MiniVibe/MiniVibe/EventLogger/Events/EngagementLog.swift
+++ b/MiniVibe/MiniVibe/EventLogger/Events/EngagementLog.swift
@@ -22,6 +22,11 @@ extension EngagementLogType {
     }
 }
 
+struct Active: EngagementLogType {
+    let userId: Int
+    let timestamp = Date()
+}
+
 struct Foreground: EngagementLogType {
     let userId: Int
     let timestamp = Date()

--- a/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
+++ b/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
@@ -33,7 +33,9 @@ struct SubscribeLogModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onTapGesture {
-                eventLogger.send(SubscribeLog(userId: 0, componentId: componentId))
+                print("event logger should be saved")
+                eventLogger.send(SubscribeLog(userId: 0,
+                                              componentId: componentId))
             }
     }
 }

--- a/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
+++ b/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
@@ -27,7 +27,9 @@ struct TransitionLogModifier: ViewModifier {
 }
 
 extension View {
+    
     func logTransition(eventLogger: EventLogger, identifier: ViewIdentifier) -> some View {
         modifier(TransitionLogModifier(eventLogger: eventLogger, identifier: identifier))
     }
+    
 }

--- a/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
+++ b/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
@@ -26,10 +26,27 @@ struct TransitionLogModifier: ViewModifier {
     }
 }
 
+struct SubscribeLogModifier: ViewModifier {
+    let eventLogger: EventLogger
+    let componentId: String
+    
+    func body(content: Content) -> some View {
+        content
+            .onTapGesture {
+                eventLogger.send(SubscribeLog(userId: 0, componentId: componentId))
+            }
+    }
+}
+
 extension View {
     
     func logTransition(eventLogger: EventLogger, identifier: ViewIdentifier) -> some View {
         modifier(TransitionLogModifier(eventLogger: eventLogger, identifier: identifier))
+    }
+    
+    func logSubscription(eventLogger: EventLogger, componentId: String) -> some View {
+        modifier(SubscribeLogModifier(eventLogger: eventLogger,
+                                      componentId: componentId))
     }
     
 }

--- a/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
+++ b/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
@@ -33,7 +33,6 @@ struct SubscribeLogModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onTapGesture {
-                print("event logger should be saved")
                 eventLogger.send(SubscribeLog(userId: 0,
                                               componentId: componentId))
             }

--- a/MiniVibe/MiniVibe/Info.plist
+++ b/MiniVibe/MiniVibe/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationExitsOnSuspend</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/MiniVibe/MiniVibe/Info.plist
+++ b/MiniVibe/MiniVibe/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>UIApplicationExitsOnSuspend</key>
-	<true/>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/MiniVibe/MiniVibe/MiniVibeApp.swift
+++ b/MiniVibe/MiniVibe/MiniVibeApp.swift
@@ -26,6 +26,9 @@ struct MiniVibeApp: App {
             MainTab()
                 .environmentObject(NowPlaying())
                 .environmentObject(eventLogger)
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                    eventLogger.send(Active(userId: 0))
+                }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
                     eventLogger.send(Background(userId: 0))
                 }

--- a/MiniVibe/MiniVibe/MiniVibeApp.swift
+++ b/MiniVibe/MiniVibe/MiniVibeApp.swift
@@ -10,29 +10,30 @@ import SwiftUI
 
 @main
 struct MiniVibeApp: App {
-    @Environment(\.scenePhase) var scenePhase
     let persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Event")
         container.loadPersistentStores(completionHandler: { _, _ in })
         return container
     }()
+    let eventLogger: EventLogger
+    
+    init() {
+        eventLogger = EventLogger(persistentContainer: persistentContainer)
+    }
     
     var body: some Scene {
         WindowGroup {
             MainTab()
                 .environmentObject(NowPlaying())
-                .environmentObject(EventLogger(persistentContainer: persistentContainer))
-                .onChange(of: scenePhase) { newScenePhase in
-                    switch newScenePhase {
-                    case .active:
-                        print("active")
-                    case .inactive:
-                        print("inactive")
-                    case .background:
-                        print("background")
-                    @unknown default:
-                        print("unknown")
-                    }
+                .environmentObject(eventLogger)
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
+                    eventLogger.send(Background(userId: 0))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+                    eventLogger.send(Foreground(userId: 0))
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
+                    eventLogger.send(Terminate(userId: 0))
                 }
         }
     }

--- a/MiniVibe/MiniVibe/MiniVibeApp.swift
+++ b/MiniVibe/MiniVibe/MiniVibeApp.swift
@@ -29,7 +29,7 @@ struct MiniVibeApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
                     eventLogger.send(Active(userId: 0))
                 }
-                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didEnterBackgroundNotification)) { _ in
                     eventLogger.send(Background(userId: 0))
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in

--- a/MiniVibe/MiniVibe/Views/Player/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Player.swift
@@ -48,19 +48,15 @@ struct Player: View {
             
             Spacer()
             
-            Button {
-                
-            } label: {
-                HStack(spacing: 2) {
-                    Text("미리듣기 중")
-                    Image(systemName: "info.circle")
-                }
-                .foregroundColor(.pink)
-                .font(.system(size: 12))
+            HStack(spacing: 2) {
+                Text("미리듣기 중")
+                Image(systemName: "info.circle")
             }
+            .foregroundColor(.pink)
+            .font(.system(size: 12))
             .logSubscription(eventLogger: eventLogger,
                              componentId: "")
-            
+
             Spacer()
             
             Button {

--- a/MiniVibe/MiniVibe/Views/Player/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Player.swift
@@ -49,9 +49,7 @@ struct Player: View {
             Spacer()
             
             Button {
-                // TO DO: action에서 분리하기
-                eventLogger.send(SubscribeLog(userId: 0,
-                                              componentId: "미리듣기"))
+                
             } label: {
                 HStack(spacing: 2) {
                     Text("미리듣기 중")
@@ -60,6 +58,8 @@ struct Player: View {
                 .foregroundColor(.pink)
                 .font(.system(size: 12))
             }
+            .logSubscription(eventLogger: eventLogger,
+                             componentId: "")
             
             Spacer()
             

--- a/MiniVibe/MiniVibe/Views/Player/UpNextList.swift
+++ b/MiniVibe/MiniVibe/Views/Player/UpNextList.swift
@@ -13,6 +13,7 @@ struct UpNextList: View {
         UITableView.appearance().showsVerticalScrollIndicator = false
     }
     
+    @EnvironmentObject private var eventLogger: EventLogger
     @EnvironmentObject private var nowPlaying: NowPlaying
     @State private var editMode = EditMode.active
     private var selectionCount: Int {
@@ -57,7 +58,6 @@ struct UpNextList: View {
                         .frame(height: 48)
                 }
             }
-            
         }
     }
     
@@ -90,10 +90,15 @@ struct UpNextList: View {
     }
     
     private func onMove(source: IndexSet, destination: Int) {
-        var destinationIndex: Int = 0
-        nowPlaying.upNext.move(fromOffsets: source, toOffset: destination)
         guard let sourceIndex = source.first else { return }
-        destinationIndex = sourceIndex < destination ?  destination - 1 : destination
+        nowPlaying.upNext.move(fromOffsets: source, toOffset: destination)
+        let destinationIndex = sourceIndex < destination ?  destination - 1 : destination
+        if sourceIndex != destinationIndex {
+            eventLogger.send(MoveTrackLog(userId: 0,
+                                          trackId: nowPlaying.upNext[destinationIndex].id,
+                                          source: sourceIndex,
+                                          destination: destinationIndex))
+        }
     }
     
     @ViewBuilder

--- a/MiniVibe/MiniVibe/Views/Today/Today.swift
+++ b/MiniVibe/MiniVibe/Views/Today/Today.swift
@@ -27,7 +27,7 @@ struct Today: View {
                 ScrollView {
                     VStack {
                         VStack(spacing: 30) {
-                            TodayTitle()
+                            TodayTitle(width: width)
                                 .padding(.horizontal, width * .paddingRatio)
                             
                             PreviewSection(width: width)

--- a/MiniVibe/MiniVibe/Views/Today/TodayTitle.swift
+++ b/MiniVibe/MiniVibe/Views/Today/TodayTitle.swift
@@ -13,9 +13,6 @@ struct TodayTitle: View {
     var body: some View {
         HStack {
             Button {
-                // TO DO: action에서 분리하기
-                eventLogger.send(SubscribeLog(userId: 0,
-                                              componentId: "내돈내듣"))
                 
             } label: {
                 Text("#내돈내듣 VIBE")
@@ -23,6 +20,8 @@ struct TodayTitle: View {
                     .font(.title)
                     .fontWeight(.heavy)
             }
+            .logSubscription(eventLogger: eventLogger,
+                             componentId: "")
             
             Spacer()
             NavigationLink(

--- a/MiniVibe/MiniVibe/Views/Today/TodayTitle.swift
+++ b/MiniVibe/MiniVibe/Views/Today/TodayTitle.swift
@@ -9,21 +9,19 @@ import SwiftUI
 
 struct TodayTitle: View {
     @EnvironmentObject private var eventLogger: EventLogger
+    let width: CGFloat
     
     var body: some View {
         HStack {
-            Button {
-                
-            } label: {
-                Text("#내돈내듣 VIBE")
-                    .foregroundColor(.black)
-                    .font(.title)
-                    .fontWeight(.heavy)
-            }
-            .logSubscription(eventLogger: eventLogger,
-                             componentId: "")
+            Text("#내돈내듣 VIBE")
+                .foregroundColor(.black)
+                .font(.title)
+                .fontWeight(.heavy)
+                .logSubscription(eventLogger: eventLogger,
+                                 componentId: "")
             
             Spacer()
+            
             NavigationLink(
                 destination: ProfileView(),
                 label: {
@@ -31,14 +29,17 @@ struct TodayTitle: View {
                         .clipShape(Circle())
                         .font(.system(size: 24))
                         .frame(width: 60, height: 60)
-                })
+                }
+            )
         }
     }
 }
 
 struct TodayTitle_Previews: PreviewProvider {
     static var previews: some View {
-        TodayTitle()
-            .previewLayout(.fixed(width: 375, height: 100))
+        GeometryReader { geometry in
+            TodayTitle(width: geometry.size.width)
+                .previewLayout(.fixed(width: 375, height: 100))
+        }
     }
 }


### PR DESCRIPTION
### 📕 Issue Number

Close #380 
Close #381 
Close #382 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] UpNext의 Track 순서 변경 이벤트 수집, 저장, 출력
- [x] Subscribe 이벤트 수집, 저장, 출력
- [x] App cycle 이벤트 수집, 저장, 출력


### 📘 작업 유형

- [x] 신규 기능 추가


### 📋 체크리스트

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- App cycle 감지하는 부분을 notification center에서 보내주는 노티 receive 하는 방식으로 수정
- 현재는 LogModifier를 한 파일에 다 작성해놓았는데 추후에 분리 예정
<br/><br/>
