### PR TITLE
[iOS] 좋아요 이벤트 저장, 수집, 출력 #387

### DIFF
--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		447ECD40257928A300EE1435 /* LibraryPlayListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447ECD3F257928A300EE1435 /* LibraryPlayListRow.swift */; };
 		448A39F82581476B00583624 /* Date+timeStampFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448A39F72581476B00583624 /* Date+timeStampFormat.swift */; };
 		448A39FC25814D5200583624 /* EventLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448A39FB25814D5200583624 /* EventLogView.swift */; };
+		449C21CA2584921700E180BB /* TrackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 449C21C92584921700E180BB /* TrackViewModel.swift */; };
 		44A90ADD25822F420032CD82 /* EventLogType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A90ADC25822F420032CD82 /* EventLogType.swift */; };
 		44ACE45F257E6B9B00EA5479 /* PlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE45E257E6B9B00EA5479 /* PlaylistUseCase.swift */; };
 		44ACE463257E7E9500EA5479 /* PlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE462257E7E9500EA5479 /* PlaylistViewModel.swift */; };
@@ -214,6 +215,7 @@
 		447ECD3F257928A300EE1435 /* LibraryPlayListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPlayListRow.swift; sourceTree = "<group>"; };
 		448A39F72581476B00583624 /* Date+timeStampFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+timeStampFormat.swift"; sourceTree = "<group>"; };
 		448A39FB25814D5200583624 /* EventLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogView.swift; sourceTree = "<group>"; };
+		449C21C92584921700E180BB /* TrackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackViewModel.swift; sourceTree = "<group>"; };
 		44A90ADC25822F420032CD82 /* EventLogType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogType.swift; sourceTree = "<group>"; };
 		44ACE45E257E6B9B00EA5479 /* PlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistUseCase.swift; sourceTree = "<group>"; };
 		44ACE462257E7E9500EA5479 /* PlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistViewModel.swift; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				80D02DFF257E0C6400A6748F /* SearchViewModel.swift */,
 				44D5FABD257FD66400A3E91C /* ArtistViewModel.swift */,
 				44D5FAC5257FDE5D00A3E91C /* ArtistSectionViewModel.swift */,
+				449C21C92584921700E180BB /* TrackViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -963,6 +966,7 @@
 				80C6207A256CF21600B5C375 /* StationItem.swift in Sources */,
 				44D5FAC2257FD89E00A3E91C /* ArtistUseCase.swift in Sources */,
 				80FA4433257640330092D25D /* PlaylistAlbumInfo.swift in Sources */,
+				449C21CA2584921700E180BB /* TrackViewModel.swift in Sources */,
 				441357EA25764C8900DC0746 /* ArtistView.swift in Sources */,
 				8084AB6D256E403900F2AAC2 /* ThumbnailRow.swift in Sources */,
 				80A5213A257902FF0051A925 /* LibrarySongsView.swift in Sources */,

--- a/MiniVibe/MiniVibe/EventLogger/EventLogger.swift
+++ b/MiniVibe/MiniVibe/EventLogger/EventLogger.swift
@@ -7,7 +7,11 @@
 
 import CoreData
 
-final class EventLogger: ObservableObject {
+protocol EventLoggerType {
+    func send(_ event: EventLogType)
+}
+
+final class EventLogger: EventLoggerType, ObservableObject {
     
     @Published var tabViewSelection: ViewIdentifier = .today {
         didSet {

--- a/MiniVibe/MiniVibe/EventLogger/Events/LikeLog.swift
+++ b/MiniVibe/MiniVibe/EventLogger/Events/LikeLog.swift
@@ -28,7 +28,7 @@ extension LikeLogType {
 
 struct LikeLog: LikeLogType {
     let userId: Int
-    let componentId: String
+    let componentId: String = "likeButton"
     var data: LogData
     var isLike: Bool
     let timestamp: Date = Date()

--- a/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
+++ b/MiniVibe/MiniVibe/EventLogger/TransitionLogModifier.swift
@@ -41,7 +41,6 @@ struct SubscribeLogModifier: ViewModifier {
 }
 
 extension View {
-   
     func logTransition(eventLogger: EventLogger, identifier: ViewIdentifier, componentId: ComponentId) -> some View {
         modifier(TransitionLogModifier(eventLogger: eventLogger, identifier: identifier, componentId: componentId))
     }
@@ -50,5 +49,4 @@ extension View {
         modifier(SubscribeLogModifier(eventLogger: eventLogger,
                                       componentId: componentId))
     }
-    
 }

--- a/MiniVibe/MiniVibe/Models/NowPlaying.swift
+++ b/MiniVibe/MiniVibe/Models/NowPlaying.swift
@@ -11,15 +11,15 @@ import Combine
 final class NowPlaying: ObservableObject {
     @Published var isPlaying: Bool = false
     @Published var isPlayerPresented: Bool = false
-    @Published var upNext = [TrackInfo]()
-    @Published var selectedTracks = Set<TrackInfo>()
-    var playingTrack: TrackInfo? {
+    @Published var upNext = [TrackViewModel]()
+    @Published var selectedTracks = Set<TrackViewModel>()
+    var playingTrack: TrackViewModel? {
         return upNext.first
     }
     let usecase = TrackUseCase()
     var cancellables = Set<AnyCancellable>()
     
-    func addTrack(track: TrackInfo) {
+    func addTrack(track: TrackViewModel) {
         isPlaying = true
         if let index = upNext.firstIndex(of: track) {
             upNext.insert(upNext.remove(at: index), at: 0)
@@ -42,27 +42,4 @@ final class NowPlaying: ObservableObject {
         isPlaying = true
         upNext.insert(upNext.remove(at: 0), at: upNext.count)
     }
-    
-    func likeTrack(id: Int) {
-        usecase.likeTrack(like: LikeTrack(trackId: id)) //sink로 받고 에러처리만 하면 될 듯?
-            .sink { _ in
-                
-            } receiveValue: { _ in
-                
-            }
-            .store(in: &cancellables)
-        upNext[0].liked = 1
-    }
-    
-    func cancelLikedTrack(id: Int) {
-        usecase.cancelLikedTrack(id: id)
-            .sink { _ in
-                
-            } receiveValue: { _ in
-                
-            }
-            .store(in: &cancellables)
-        upNext[0].liked = 0
-    }
-
 }

--- a/MiniVibe/MiniVibe/ViewModels/AlbumViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/AlbumViewModel.swift
@@ -12,6 +12,7 @@ final class AlbumViewModel: ObservableObject {
         case appear
         case showAlbumMenu
         case showTrackMenu(info: TrackViewModel)
+        case like
     }
     
     enum ActiveSheet {
@@ -20,6 +21,7 @@ final class AlbumViewModel: ObservableObject {
     }
     
     private let useCase = AlbumUseCase()
+    private let eventLogger: EventLoggerType
     private var cancellables = Set<AnyCancellable>()
     private let id: Int
     @Published private(set) var album: Album?
@@ -27,8 +29,9 @@ final class AlbumViewModel: ObservableObject {
     @Published var showSheet = false
     @Published var isOpenArticle = false
     
-    init(id: Int) {
+    init(id: Int, eventLogger: EventLoggerType) {
         self.id = id
+        self.eventLogger = eventLogger
     }
     
     func send(_ input: Input) {
@@ -41,6 +44,8 @@ final class AlbumViewModel: ObservableObject {
         case let .showTrackMenu(info):
             activeSheet = .track(info: info)
             showSheet = true
+        case .like:
+            like()
         }
     }
     
@@ -52,5 +57,12 @@ final class AlbumViewModel: ObservableObject {
                 self?.album = album
             }
             .store(in: &cancellables)
+    }
+    
+    private func like() {
+        eventLogger.send(LikeLog(userId: 0,
+                                 data: .init(type: "Album",
+                                             id: id),
+                                 isLike: true))
     }
 }

--- a/MiniVibe/MiniVibe/ViewModels/AlbumViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/AlbumViewModel.swift
@@ -9,28 +9,32 @@ import Combine
 
 final class AlbumViewModel: ObservableObject {
     enum Input {
-        case appear(albumID: Int)
+        case appear
         case showAlbumMenu
-        case showTrackMenu(info: TrackInfo)
+        case showTrackMenu(info: TrackViewModel)
     }
     
     enum ActiveSheet {
         case album
-        case track(info: TrackInfo)
+        case track(info: TrackViewModel)
     }
     
     private let useCase = AlbumUseCase()
     private var cancellables = Set<AnyCancellable>()
-    
+    private let id: Int
     @Published private(set) var album: Album?
     @Published private(set) var activeSheet: ActiveSheet = .album
     @Published var showSheet = false
     @Published var isOpenArticle = false
     
+    init(id: Int) {
+        self.id = id
+    }
+    
     func send(_ input: Input) {
         switch input {
-        case let .appear(albumID):
-            load(albumID: albumID)
+        case .appear:
+            load()
         case .showAlbumMenu:
             activeSheet = .album
             showSheet = true
@@ -40,8 +44,8 @@ final class AlbumViewModel: ObservableObject {
         }
     }
     
-    private func load(albumID: Int) {
-        useCase.loadAlbum(with: albumID)
+    private func load() {
+        useCase.loadAlbum(with: id)
             .sink { _ in
                 
             } receiveValue: { [weak self] album in

--- a/MiniVibe/MiniVibe/ViewModels/PlaylistViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/PlaylistViewModel.swift
@@ -12,6 +12,7 @@ final class PlaylistViewModel: ObservableObject {
         case appear
         case showPlaylistMenu
         case showTrackMenu(info: TrackViewModel)
+        case like
     }
     
     enum ActiveSheet {
@@ -20,6 +21,7 @@ final class PlaylistViewModel: ObservableObject {
     }
     
     private let useCase = PlaylistUseCase()
+    private let eventLogger: EventLoggerType
     private var cancellables = Set<AnyCancellable>()
     private let id: Int
     
@@ -28,8 +30,9 @@ final class PlaylistViewModel: ObservableObject {
     @Published var showSheet = false
     @Published var isOpenArticle = false
     
-    init(id: Int) {
+    init(id: Int, eventLogger: EventLoggerType) {
         self.id = id
+        self.eventLogger = eventLogger
     }
     
     func send(_ input: Input) {
@@ -42,6 +45,8 @@ final class PlaylistViewModel: ObservableObject {
         case let .showTrackMenu(info):
             activeSheet = .track(info: info)
             showSheet = true
+        case .like:
+            like()
         }
     }
     
@@ -53,5 +58,12 @@ final class PlaylistViewModel: ObservableObject {
                 self?.playlist = playlist
             }
             .store(in: &cancellables)
+    }
+    
+    private func like() {
+        eventLogger.send(LikeLog(userId: 0,
+                                 data: .init(type: "Playlist",
+                                             id: id),
+                                 isLike: true))
     }
 }

--- a/MiniVibe/MiniVibe/ViewModels/PlaylistViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/PlaylistViewModel.swift
@@ -9,28 +9,33 @@ import Combine
 
 final class PlaylistViewModel: ObservableObject {
     enum Input {
-        case appear(playlistID: Int)
+        case appear
         case showPlaylistMenu
-        case showTrackMenu(info: TrackInfo)
+        case showTrackMenu(info: TrackViewModel)
     }
     
     enum ActiveSheet {
         case playlist
-        case track(info: TrackInfo)
+        case track(info: TrackViewModel)
     }
     
     private let useCase = PlaylistUseCase()
     private var cancellables = Set<AnyCancellable>()
+    private let id: Int
     
     @Published private(set) var playlist: Playlist?
     @Published private(set) var activeSheet: ActiveSheet = .playlist
     @Published var showSheet = false
     @Published var isOpenArticle = false
     
+    init(id: Int) {
+        self.id = id
+    }
+    
     func send(_ input: Input) {
         switch input {
-        case let .appear(playlistID):
-            load(playlistID: playlistID)
+        case .appear:
+            load()
         case .showPlaylistMenu:
             activeSheet = .playlist
             showSheet = true
@@ -40,8 +45,8 @@ final class PlaylistViewModel: ObservableObject {
         }
     }
     
-    private func load(playlistID: Int) {
-        useCase.loadPlaylist(with: playlistID)
+    private func load() {
+        useCase.loadPlaylist(with: id)
             .sink { _ in
 
             } receiveValue: { [weak self] playlist in

--- a/MiniVibe/MiniVibe/ViewModels/TrackViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/TrackViewModel.swift
@@ -10,12 +10,14 @@ import Foundation
 
 final class TrackViewModel: ObservableObject {
     @Published var track: TrackInfo
+    private let eventLogger: EventLoggerType
     private let useCase: TrackUseCase
     private var cancellables: Set<AnyCancellable> = []
     
-    init(track: TrackInfo, useCase: TrackUseCase = .init()) {
+    init(track: TrackInfo, useCase: TrackUseCase = .init(), eventLogger: EventLoggerType) {
         self.track = track
         self.useCase = useCase
+        self.eventLogger = eventLogger
     }
     
     func like() {
@@ -24,8 +26,13 @@ final class TrackViewModel: ObservableObject {
                 .sink { _ in
                     
                 } receiveValue: { [weak self] isSuccess in
+                    guard let self = self else { return }
                     if isSuccess {
-                        self?.track.liked = 1
+                        self.track.liked = 1
+                        self.eventLogger.send(LikeLog(userId: 0,
+                                                       componentId: "likeButton",
+                                                       data: .init(type: "Track", id: self.track.id),
+                                                       isLike: true))
                     }
                 }
                 .store(in: &cancellables)
@@ -34,8 +41,13 @@ final class TrackViewModel: ObservableObject {
                 .sink { _ in
                     
                 } receiveValue: { [weak self] isSuccess in
+                    guard let self = self else { return }
                     if isSuccess {
-                        self?.track.liked = 0
+                        self.track.liked = 0
+                        self.eventLogger.send(LikeLog(userId: 0,
+                                                       componentId: "likeButton",
+                                                       data: .init(type: "Track", id: self.track.id),
+                                                       isLike: false))
                     }
                 }
                 .store(in: &cancellables)

--- a/MiniVibe/MiniVibe/ViewModels/TrackViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/TrackViewModel.swift
@@ -1,0 +1,56 @@
+//
+//  TrackViewModel.swift
+//  MiniVibe
+//
+//  Created by TTOzzi on 2020/12/12.
+//
+
+import Combine
+import Foundation
+
+final class TrackViewModel: ObservableObject {
+    @Published var track: TrackInfo
+    private let useCase: TrackUseCase
+    private var cancellables: Set<AnyCancellable> = []
+    
+    init(track: TrackInfo, useCase: TrackUseCase = .init()) {
+        self.track = track
+        self.useCase = useCase
+    }
+    
+    func like() {
+        if track.liked == 0 {
+            useCase.likeTrack(like: LikeTrack(trackId: track.id))
+                .sink { _ in
+                    
+                } receiveValue: { [weak self] isSuccess in
+                    if isSuccess {
+                        self?.track.liked = 1
+                    }
+                }
+                .store(in: &cancellables)
+        } else {
+            useCase.cancelLikedTrack(id: track.id)
+                .sink { _ in
+                    
+                } receiveValue: { [weak self] isSuccess in
+                    if isSuccess {
+                        self?.track.liked = 0
+                    }
+                }
+                .store(in: &cancellables)
+        }
+    }
+}
+
+extension TrackViewModel: Equatable {
+    static func == (lhs: TrackViewModel, rhs: TrackViewModel) -> Bool {
+        return lhs.track == rhs.track
+    }
+}
+
+extension TrackViewModel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(track)
+    }
+}

--- a/MiniVibe/MiniVibe/ViewModels/TrackViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/TrackViewModel.swift
@@ -30,7 +30,6 @@ final class TrackViewModel: ObservableObject {
                     if isSuccess {
                         self.track.liked = 1
                         self.eventLogger.send(LikeLog(userId: 0,
-                                                       componentId: "likeButton",
                                                        data: .init(type: "Track", id: self.track.id),
                                                        isLike: true))
                     }
@@ -45,7 +44,6 @@ final class TrackViewModel: ObservableObject {
                     if isSuccess {
                         self.track.liked = 0
                         self.eventLogger.send(LikeLog(userId: 0,
-                                                       componentId: "likeButton",
                                                        data: .init(type: "Track", id: self.track.id),
                                                        isLike: false))
                     }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
@@ -31,7 +31,8 @@ struct AlbumSection<D: View>: View {
                     ForEach(albums, id: \.id) { album in
                         NavigationLink(
                             destination:
-                                AlbumView(viewModel: .init(id: album.id))
+                                AlbumView(viewModel: .init(id: album.id,
+                                                           eventLogger: eventLogger))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .album(id: album.id),
                                                componentId: .albumItem)

--- a/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
@@ -31,7 +31,7 @@ struct AlbumSection<D: View>: View {
                     ForEach(albums, id: \.id) { album in
                         NavigationLink(
                             destination:
-                                AlbumView(id: album.id)
+                                AlbumView(viewModel: .init(id: album.id))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .album(id: album.id),
                                                componentId: .albumItem)

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -89,7 +89,7 @@ struct AlbumView: View {
                     .fullScreenCover(isPresented: $viewModel.showSheet) {
                         switch viewModel.activeSheet {
                         case .album:
-                            AlbumMenu(album: album)
+                            AlbumMenu(viewModel: viewModel)
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .albumMenu(id: album.id),
                                                componentId: .albumMenuButton)
@@ -113,7 +113,7 @@ struct AlbumView: View {
     private var trailingBarButtons: some View {
         HStack(spacing: 10) {
             Button {
-                
+                viewModel.send(.like)
             } label: {
                 Image(systemName: "heart")
             }
@@ -140,7 +140,8 @@ struct AlbumView: View {
 struct AlbumPlaylistView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            AlbumView(viewModel: AlbumViewModel(id: 11))
+            AlbumView(viewModel: AlbumViewModel(id: 11,
+                                                eventLogger: EventLogger(persistentContainer: .init())))
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -8,13 +8,12 @@
 import SwiftUI
 
 struct AlbumView: View {
-    init(id: Int) {
-        self.id = id
+    init(viewModel: AlbumViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
     
     @EnvironmentObject private var eventLogger: EventLogger
-    @StateObject private var viewModel = AlbumViewModel()
-    private let id: Int
+    @StateObject private var viewModel: AlbumViewModel
     
     var body: some View {
         content
@@ -53,8 +52,9 @@ struct AlbumView: View {
                                     ) {
                                         Section(header: PlayAndShuffle(width: geometry.size.width)) {
                                             ForEach(tracks, id: \.id) { track in
-                                                TrackRowD(track: track, order: 1) {
-                                                    viewModel.send(.showTrackMenu(info: track))
+                                                let trackViewModel = TrackViewModel(track: track)
+                                                TrackRowD(viewModel: trackViewModel, order: 1) {
+                                                    viewModel.send(.showTrackMenu(info: $0))
                                                 }
                                             }
                                         }
@@ -93,9 +93,9 @@ struct AlbumView: View {
                                                identifier: .albumMenu(id: album.id),
                                                componentId: .albumMenuButton)
                         case let .track(info):
-                            PlayerMenu(track: info)
+                            PlayerMenu(viewModel: info)
                                 .logTransition(eventLogger: eventLogger,
-                                               identifier: .playerMenu(id: info.id),
+                                               identifier: .playerMenu(id: info.track.id),
                                                componentId: .trackMenuButton)
                         }
                     }
@@ -104,7 +104,7 @@ struct AlbumView: View {
         } else {
             Color.clear
                 .onAppear {
-                    viewModel.send(.appear(albumID: id))
+                    viewModel.send(.appear)
                 }
         }
     }
@@ -139,7 +139,7 @@ struct AlbumView: View {
 struct AlbumPlaylistView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            AlbumView(id: 11)
+            AlbumView(viewModel: AlbumViewModel(id: 11))
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -52,8 +52,9 @@ struct AlbumView: View {
                                     ) {
                                         Section(header: PlayAndShuffle(width: geometry.size.width)) {
                                             ForEach(tracks, id: \.id) { track in
-                                                let trackViewModel = TrackViewModel(track: track)
-                                                TrackRowD(viewModel: trackViewModel, order: 1) {
+                                                TrackRowD(viewModel: TrackViewModel(track: track,
+                                                                                    eventLogger: eventLogger),
+                                                          order: 1) {
                                                     viewModel.send(.showTrackMenu(info: $0))
                                                 }
                                             }

--- a/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
@@ -38,7 +38,7 @@ struct ArtistView: View {
                             
                             VStack(spacing: 12) {
                                 ForEach(artist.tracks, id: \.id) { track in
-                                    TrackRowB(track: track)
+                                    TrackRowB(viewModel: .init(track: track))
                                 }
                                 .frame(width: width * .sectionRatio)
                             }

--- a/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
@@ -38,7 +38,7 @@ struct ArtistView: View {
                             
                             VStack(spacing: 12) {
                                 ForEach(artist.tracks, id: \.id) { track in
-                                    TrackRowB(viewModel: .init(track: track))
+                                    TrackRowB(viewModel: .init(track: track, eventLogger: eventLogger))
                                 }
                                 .frame(width: width * .sectionRatio)
                             }

--- a/MiniVibe/MiniVibe/Views/Common/ChartList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartList.swift
@@ -21,7 +21,7 @@ struct ChartList: View {
                 ) {
                     Section(header: PlayAndShuffle(width: geometry.size.width)) {
                         ForEach(tracks, id: \.id) { track in
-                            TrackRowA(order: 1, track: track)
+                            TrackRowA(viewModel: .init(track: track), order: 1)
                         }
                     }
                     .padding(.horizontal, geometry.size.width * .paddingRatio)

--- a/MiniVibe/MiniVibe/Views/Common/ChartList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartList.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ChartList: View {
+    @EnvironmentObject private var eventLogger: EventLogger
     let title: String
     let tracks: [TrackInfo]
     
@@ -21,7 +22,9 @@ struct ChartList: View {
                 ) {
                     Section(header: PlayAndShuffle(width: geometry.size.width)) {
                         ForEach(tracks, id: \.id) { track in
-                            TrackRowA(viewModel: .init(track: track), order: 1)
+                            TrackRowA(viewModel: .init(track: track,
+                                                       eventLogger: eventLogger),
+                                      order: 1)
                         }
                     }
                     .padding(.horizontal, geometry.size.width * .paddingRatio)

--- a/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionA.swift
@@ -26,7 +26,7 @@ struct ChartSectionA: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHGrid(rows: .init(repeating: .init(.flexible(minimum: 60)), count: 5)) {
                     ForEach(tracks, id: \.id) { track in
-                        TrackRowB(viewModel: .init(track: track))
+                        TrackRowB(viewModel: .init(track: track, eventLogger: eventLogger))
                     }
                     .frame(width: width * .sectionRatio)
                 }

--- a/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionA.swift
@@ -26,7 +26,7 @@ struct ChartSectionA: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHGrid(rows: .init(repeating: .init(.flexible(minimum: 60)), count: 5)) {
                     ForEach(tracks, id: \.id) { track in
-                        TrackRowB(track: track)
+                        TrackRowB(viewModel: .init(track: track))
                     }
                     .frame(width: width * .sectionRatio)
                 }

--- a/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionB.swift
@@ -25,7 +25,9 @@ struct ChartSectionB: View {
                 // 무조건 100개
                 LazyHGrid(rows: .init(repeating: .init(.flexible(minimum: 60)), count: 5)) {
                     ForEach(0..<100) { index in
-                        TrackRowE(viewModel: .init(track: trackinfo), order: index)
+                        TrackRowE(viewModel: .init(track: trackinfo,
+                                                   eventLogger: eventLogger),
+                                  order: index)
                     }
                     .frame(width: width * .sectionRatio)
                 }

--- a/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionB.swift
@@ -25,7 +25,7 @@ struct ChartSectionB: View {
                 // 무조건 100개
                 LazyHGrid(rows: .init(repeating: .init(.flexible(minimum: 60)), count: 5)) {
                     ForEach(0..<100) { index in
-                        TrackRowE(order: index, track: trackinfo)
+                        TrackRowE(viewModel: .init(track: trackinfo), order: index)
                     }
                     .frame(width: width * .sectionRatio)
                 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
@@ -15,7 +15,9 @@ struct AlbumMenu: View {
     var body: some View {
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton()
+            MenuThumbnailButton(imageUrl: album.imageUrl,
+                                title: album.title,
+                                subtitle: album.artist.name)
             MenuButton(type: .download(.album)) {
                 
             }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/AlbumMenu.swift
@@ -10,19 +10,24 @@ import SwiftUI
 struct AlbumMenu: View {
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var eventLogger: EventLogger
-    let album: Album
+    @StateObject private var viewModel: AlbumViewModel
+    
+    init(viewModel: AlbumViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
     
     var body: some View {
+        let album = viewModel.album
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton(imageUrl: album.imageUrl,
-                                title: album.title,
-                                subtitle: album.artist.name)
+            MenuThumbnailButton(imageUrl: album?.imageUrl ?? "",
+                                title: album?.title ?? "",
+                                subtitle: album?.artist.name ?? "")
             MenuButton(type: .download(.album)) {
                 
             }
             MenuButton(type: .like(0)) {
-                
+                viewModel.send(.like)
             }
             MenuButton(type: .addToPlaylist) {
                 
@@ -39,6 +44,6 @@ struct AlbumMenu: View {
 
 struct AlbumMenu_Previews: PreviewProvider {
     static var previews: some View {
-        AlbumMenu(album: .init(id: 1, title: "", description: "", releaseDate: "", artist: .init(id: 1, name: ""), imageUrl: "", tracks: []))
+        AlbumMenu(viewModel: .init(id: 1, eventLogger: EventLogger(persistentContainer: .init())))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
@@ -9,23 +9,24 @@ import SwiftUI
 import KingfisherSwiftUI
 
 struct MenuThumbnailButton: View {
-    @EnvironmentObject private var nowPlaying: NowPlaying
+    let imageUrl: String
+    let title: String
+    let subtitle: String
     
     var body: some View {
 
         HStack {
-            KFImage(URL(string: nowPlaying.playingTrack?.album.imageUrl ?? ""))
+            KFImage(URL(string: imageUrl))
                 .resizable()
                 .aspectRatio(1, contentMode: .fit)
                 .frame(width: 80)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(nowPlaying.playingTrack?.title ?? "")
+                Text(title)
                     .font(.system(size: 18, weight: .bold))
 
-                Text(nowPlaying.playingTrack?.artist.name ?? "")
+                Text(subtitle)
                     .foregroundColor(.secondary)
-                    .opacity(nowPlaying.playingTrack?.artist == nil ? 0 : 1)
             }
             .lineLimit(1)
             .padding(.horizontal, 8)
@@ -40,6 +41,6 @@ struct MenuThumbnailButton: View {
 
 struct MenuThumbnailButton_Previews: PreviewProvider {
     static var previews: some View {
-        MenuThumbnailButton()
+        MenuThumbnailButton(imageUrl: "", title: "", subtitle: "")
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayListMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayListMenu.swift
@@ -8,20 +8,25 @@
 import SwiftUI
 
 struct PlayListMenu: View {
+    init(viewModel: PlaylistViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
+    
     @Environment(\.presentationMode) var presentationMode
-    let playlist: Playlist
+    @StateObject private var viewModel: PlaylistViewModel
     
     var body: some View {
+        let playlist = viewModel.playlist
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton(imageUrl: playlist.imageUrl,
-                                title: playlist.title,
-                                subtitle: playlist.subTitle ?? "")
+            MenuThumbnailButton(imageUrl: playlist?.imageUrl ?? "",
+                                title: playlist?.title ?? "",
+                                subtitle: playlist?.subTitle ?? "")
             MenuButton(type: .download(.playList)) {
                 
             }
             MenuButton(type: .like(0)) {
-                
+                viewModel.send(.like)
             }
             MenuButton(type: .addToPlaylist) {
                 
@@ -38,6 +43,6 @@ struct PlayListMenu: View {
 
 struct PlayListMenu_Previews: PreviewProvider {
     static var previews: some View {
-        PlayListMenu(playlist: .init(id: 0, title: "", subTitle: "", description: "", imageUrl: "", customized: false, tracks: []))
+        PlayListMenu(viewModel: .init(id: 0, eventLogger: EventLogger(persistentContainer: .init())))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayListMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayListMenu.swift
@@ -14,7 +14,9 @@ struct PlayListMenu: View {
     var body: some View {
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton()
+            MenuThumbnailButton(imageUrl: playlist.imageUrl,
+                                title: playlist.title,
+                                subtitle: playlist.subTitle ?? "")
             MenuButton(type: .download(.playList)) {
                 
             }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
@@ -8,20 +8,19 @@
 import SwiftUI
 
 struct PlayerMenu: View {
-    @EnvironmentObject private var nowPlaying: NowPlaying
     @Environment(\.presentationMode) var presentationMode
-    let track: TrackInfo
+    @EnvironmentObject private var nowPlaying: NowPlaying
+    @ObservedObject var viewModel: TrackViewModel
     
     var body: some View {
         VStack(spacing: 36) {
             Spacer()
-            MenuThumbnailButton()
-            MenuButton(type: .like(nowPlaying.playingTrack?.liked ?? 0)) {
-                if nowPlaying.playingTrack?.liked == 1 {
-                    nowPlaying.cancelLikedTrack(id: nowPlaying.playingTrack?.id ?? 0)
-                } else {
-                    nowPlaying.likeTrack(id: nowPlaying.playingTrack?.id ?? 0)
-                }
+            let track = viewModel.track
+            MenuThumbnailButton(imageUrl: track.album.imageUrl,
+                                title: track.title,
+                                subtitle: track.artist.name)
+            MenuButton(type: .like(track.liked)) {
+                viewModel.like()
             }
             MenuButton(type: .exclude) {
                 
@@ -44,6 +43,6 @@ struct PlayerMenu: View {
 
 struct PlayerMenu_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerMenu(track: trackinfo)
+        PlayerMenu(viewModel: .init(track: trackinfo))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
@@ -43,6 +43,6 @@ struct PlayerMenu: View {
 
 struct PlayerMenu_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerMenu(viewModel: .init(track: trackinfo))
+        PlayerMenu(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/PlayerPreview.swift
+++ b/MiniVibe/MiniVibe/Views/Common/PlayerPreview.swift
@@ -35,15 +35,16 @@ struct PlayerPreview: View {
     }
     
     @ViewBuilder private func playingTrackInfo() -> some View {
-        KFImage(URL(string: nowPlaying.playingTrack?.album.imageUrl ?? ""))
+        let track = nowPlaying.playingTrack?.track
+        KFImage(URL(string: track?.album.imageUrl ?? ""))
             .resizable()
             .frame(width: height, height: height)
         
         VStack(alignment: .leading) {
-            Text(nowPlaying.playingTrack?.title ?? "What's on today?")
+            Text(track?.title ?? "What's on today?")
                 .font(.system(size: 15))
             
-            Text(nowPlaying.playingTrack?.artist.name ?? "Tap the play button")
+            Text(track?.artist.name ?? "Tap the play button")
                 .font(.system(size: 12))
                 .foregroundColor(.secondary)
         }

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
@@ -20,7 +20,7 @@ struct ThumbnailGrid: View {
                     ForEach(albums, id: \.id) { album in
                         NavigationLink(
                             destination:
-                                AlbumView(id: album.id)
+                                AlbumView(viewModel: .init(id: album.id))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .album(id: album.id),
                                                componentId: .albumItem)

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
@@ -20,7 +20,8 @@ struct ThumbnailGrid: View {
                     ForEach(albums, id: \.id) { album in
                         NavigationLink(
                             destination:
-                                AlbumView(viewModel: .init(id: album.id))
+                                AlbumView(viewModel: .init(id: album.id,
+                                                           eventLogger: eventLogger))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .album(id: album.id),
                                                componentId: .albumItem)

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
@@ -40,7 +40,7 @@ struct ThumbnailList: View {
         case let .playlist(data):
             ForEach(data, id: \.id) { playlist in
                 NavigationLink(destination:
-                                PlayListView(id: playlist.id)
+                                PlayListView(viewModel: .init(id: playlist.id))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlist(id: playlist.id),
                                                componentId: ComponentId.playlistRow)

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
@@ -40,7 +40,8 @@ struct ThumbnailList: View {
         case let .playlist(data):
             ForEach(data, id: \.id) { playlist in
                 NavigationLink(destination:
-                                PlayListView(viewModel: .init(id: playlist.id))
+                                PlayListView(viewModel: .init(id: playlist.id,
+                                                              eventLogger: eventLogger))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlist(id: playlist.id),
                                                componentId: ComponentId.playlistRow)

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
@@ -24,7 +24,8 @@ struct TrackRowA: View {
         let track = viewModel.track
         HStack {
             NavigationLink(destination:
-                            AlbumView(viewModel: .init(id: track.album.id))
+                            AlbumView(viewModel: .init(id: track.album.id,
+                                                       eventLogger: eventLogger))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
@@ -73,7 +73,7 @@ struct TrackRowA: View {
 
 struct TrackRow_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowA(viewModel: .init(track: trackinfo), order: 3)
+        TrackRowA(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), order: 3)
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
@@ -12,14 +12,19 @@ struct TrackRowA: View {
     @EnvironmentObject private var eventLogger: EventLogger
     @EnvironmentObject private var nowPlaying: NowPlaying
     @State private var isMenuOpen = false
+    @StateObject private var viewModel: TrackViewModel
+    private let order: Int
     
-    let order: Int
-    let track: TrackInfo
+    init(viewModel: TrackViewModel, order: Int) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.order = order
+    }
     
     var body: some View {
+        let track = viewModel.track
         HStack {
             NavigationLink(destination:
-                            AlbumView(id: track.album.id)
+                            AlbumView(viewModel: .init(id: track.album.id))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)
@@ -31,7 +36,7 @@ struct TrackRowA: View {
             }
             
             Button {
-                nowPlaying.addTrack(track: track)
+                nowPlaying.addTrack(track: viewModel)
             } label: {
                 Text("\(order)")
                     .font(.title3)
@@ -61,14 +66,14 @@ struct TrackRowA: View {
             }
         }
         .fullScreenCover(isPresented: $isMenuOpen) {
-            PlayerMenu(track: track)
+            PlayerMenu(viewModel: viewModel)
         }
     }
 }
 
 struct TrackRow_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowA(order: 0, track: trackinfo)
+        TrackRowA(viewModel: .init(track: trackinfo), order: 3)
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
@@ -11,12 +11,17 @@ import KingfisherSwiftUI
 struct TrackRowB: View {
     @EnvironmentObject private var eventLogger: EventLogger
     @EnvironmentObject private var nowPlaying: NowPlaying
-    let track: TrackInfo
+    @StateObject private var viewModel: TrackViewModel
+    
+    init(viewModel: TrackViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
 
     var body: some View {
+        let track = viewModel.track
         HStack {
             NavigationLink(destination:
-                            AlbumView(id: track.album.id)
+                            AlbumView(viewModel: .init(id: track.album.id))
                             .logTransition(eventLogger: eventLogger,
                                             identifier: .album(id: track.album.id),
                                             componentId: .trackRowThumbnail)
@@ -28,7 +33,7 @@ struct TrackRowB: View {
             }
             
             Button {
-                nowPlaying.addTrack(track: track)
+                nowPlaying.addTrack(track: viewModel)
             } label: {
                 VStack(alignment: .leading, spacing: 4) {
                     Spacer()
@@ -49,7 +54,7 @@ struct TrackRowB: View {
 
 struct TrackRowB_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowB(track: trackinfo)
+        TrackRowB(viewModel: .init(track: trackinfo))
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
@@ -21,7 +21,8 @@ struct TrackRowB: View {
         let track = viewModel.track
         HStack {
             NavigationLink(destination:
-                            AlbumView(viewModel: .init(id: track.album.id))
+                            AlbumView(viewModel: .init(id: track.album.id,
+                                                       eventLogger: eventLogger))
                             .logTransition(eventLogger: eventLogger,
                                             identifier: .album(id: track.album.id),
                                             componentId: .trackRowThumbnail)

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
@@ -54,7 +54,7 @@ struct TrackRowB: View {
 
 struct TrackRowB_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowB(viewModel: .init(track: trackinfo))
+        TrackRowB(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())))
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
@@ -11,33 +11,39 @@ import KingfisherSwiftUI
 struct TrackRowC: View {
     @EnvironmentObject private var nowPlaying: NowPlaying
     @EnvironmentObject private var eventLogger: EventLogger
-    let track: TrackInfo
-    let menuButtonAction: () -> Void
+    @StateObject private var viewModel: TrackViewModel
+    private let menuButtonAction: (TrackViewModel) -> Void
 
+    init(viewModel: TrackViewModel, menuButtonAction: @escaping (TrackViewModel) -> Void) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.menuButtonAction = menuButtonAction
+    }
+    
     var body: some View {
         HStack {
+            let track = viewModel.track
             NavigationLink(destination:
-                            AlbumView(id: track.album.id)
+                            AlbumView(viewModel: .init(id: track.album.id))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)
             ) {
-                KFImage(URL(string: track.album.imageUrl))
+                KFImage(URL(string: viewModel.track.album.imageUrl))
                     .resizable()
                     .frame(width: 50, height: 50)
                     .border(Color.gray, width: 0.7)
             }
             
             Button {
-                nowPlaying.addTrack(track: track)
+                nowPlaying.addTrack(track: viewModel)
             } label: {
                 VStack(alignment: .leading, spacing: 4) {
                     Spacer()
-                    Text(track.title)
+                    Text(viewModel.track.title)
                         .font(.system(size: 17))
                         .foregroundColor(.black)
                         
-                    Text(track.artist.name)
+                    Text(viewModel.track.artist.name)
                         .font(.system(size: 13))
                         .foregroundColor(.secondary)
                     Spacer()
@@ -46,7 +52,7 @@ struct TrackRowC: View {
             }
             
             Button {
-                menuButtonAction()
+                menuButtonAction(viewModel)
             } label: {
                 Image(systemName: "ellipsis")
                     .foregroundColor(.black)
@@ -60,7 +66,7 @@ struct TrackRowC: View {
 
 struct TrackRowC_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowC(track: trackinfo, menuButtonAction: {})
+        TrackRowC(viewModel: .init(track: trackinfo), menuButtonAction: { _ in })
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
@@ -66,7 +66,7 @@ struct TrackRowC: View {
 
 struct TrackRowC_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowC(viewModel: .init(track: trackinfo), menuButtonAction: { _ in })
+        TrackRowC(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), menuButtonAction: { _ in })
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
@@ -23,7 +23,8 @@ struct TrackRowC: View {
         HStack {
             let track = viewModel.track
             NavigationLink(destination:
-                            AlbumView(viewModel: .init(id: track.album.id))
+                            AlbumView(viewModel: .init(id: track.album.id,
+                                                       eventLogger: eventLogger))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)
@@ -57,7 +58,7 @@ struct TrackRowC: View {
                 Image(systemName: "ellipsis")
                     .foregroundColor(.black)
                     .padding()
-            }            
+            }
         }
         .padding(.vertical, 8)
     }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
@@ -57,8 +57,7 @@ struct TrackRowC: View {
                 Image(systemName: "ellipsis")
                     .foregroundColor(.black)
                     .padding()
-            }
-            
+            }            
         }
         .padding(.vertical, 8)
     }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
@@ -54,7 +54,7 @@ struct TrackRowD: View {
 
 struct TrackRowD_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowD(viewModel: .init(track: trackinfo), order: 1, menuButtonAction: { _ in })
+        TrackRowD(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), order: 1, menuButtonAction: { _ in })
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
@@ -9,14 +9,20 @@ import SwiftUI
 
 struct TrackRowD: View {
     @EnvironmentObject private var nowPlaying: NowPlaying
-    let track: TrackInfo
-    let order: Int
-    let menuButtonAction: () -> Void
+    @StateObject private var viewModel: TrackViewModel
+    private let order: Int
+    private let menuButtonAction: (TrackViewModel) -> Void
 
+    init(viewModel: TrackViewModel, order: Int, menuButtonAction: @escaping (TrackViewModel) -> Void) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.order = order
+        self.menuButtonAction = menuButtonAction
+    }
+    
     var body: some View {
         HStack {
             Button {
-                nowPlaying.addTrack(track: track)
+                nowPlaying.addTrack(track: viewModel)
             } label: {
                 HStack {
                     HStack {
@@ -25,7 +31,7 @@ struct TrackRowD: View {
                             .bold()
                             .padding(.horizontal, 4)
                         
-                        Text(track.title)
+                        Text(viewModel.track.title)
                             .font(.title3)
                     }
                     .padding(.vertical, 10)
@@ -35,20 +41,20 @@ struct TrackRowD: View {
             Spacer()
             
             Button {
-                menuButtonAction()
+                menuButtonAction(viewModel)
             } label: {
                 Image(systemName: "ellipsis")
-                    .foregroundColor(.black)
             }
             .padding()
         }
+        .foregroundColor(.black)
         .padding(.vertical, 8)
     }
 }
 
 struct TrackRowD_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowD(track: trackinfo, order: 1, menuButtonAction: {})
+        TrackRowD(viewModel: .init(track: trackinfo), order: 1, menuButtonAction: { _ in })
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
@@ -23,7 +23,8 @@ struct TrackRowE: View {
         HStack {
             let track = viewModel.track
             NavigationLink(destination:
-                            AlbumView(viewModel: .init(id: track.album.id))
+                            AlbumView(viewModel: .init(id: track.album.id,
+                                                       eventLogger: eventLogger))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
@@ -61,7 +61,7 @@ struct TrackRowE: View {
 
 struct TrackRowE_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowE(viewModel: .init(track: trackinfo), order: 3)
+        TrackRowE(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), order: 3)
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
@@ -11,13 +11,19 @@ import KingfisherSwiftUI
 struct TrackRowE: View {
     @EnvironmentObject private var eventLogger: EventLogger
     @EnvironmentObject private var nowPlaying: NowPlaying
+    @StateObject private var viewModel: TrackViewModel
     let order: Int
-    let track: TrackInfo
+    
+    init(viewModel: TrackViewModel, order: Int) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.order = order
+    }
 
     var body: some View {
         HStack {
+            let track = viewModel.track
             NavigationLink(destination:
-                            AlbumView(id: track.album.id)
+                            AlbumView(viewModel: .init(id: track.album.id))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)
@@ -29,7 +35,7 @@ struct TrackRowE: View {
             }
             
             Button {
-                nowPlaying.addTrack(track: track)
+                nowPlaying.addTrack(track: viewModel)
             } label: {
                 Text("\(order)")
                     .font(.title3)
@@ -55,7 +61,7 @@ struct TrackRowE: View {
 
 struct TrackRowE_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowE(order: 3, track: trackinfo)
+        TrackRowE(viewModel: .init(track: trackinfo), order: 3)
             .previewLayout(.fixed(width: 375, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Library/LibraryAlbumsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryAlbumsView.swift
@@ -35,7 +35,7 @@ struct LibraryAlbumsView: View {
                         let subtitle = "VIBE"
                         NavigationLink(
                             destination:
-                                AlbumView(id: 11)
+                                AlbumView(viewModel: .init(id: 11))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .album(id: 11),
                                                componentId: .albumItem)

--- a/MiniVibe/MiniVibe/Views/Library/LibraryAlbumsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryAlbumsView.swift
@@ -35,7 +35,8 @@ struct LibraryAlbumsView: View {
                         let subtitle = "VIBE"
                         NavigationLink(
                             destination:
-                                AlbumView(viewModel: .init(id: 11))
+                                AlbumView(viewModel: .init(id: 11,
+                                                           eventLogger: eventLogger))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .album(id: 11),
                                                componentId: .albumItem)

--- a/MiniVibe/MiniVibe/Views/Library/LibraryPlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryPlayListView.swift
@@ -52,7 +52,7 @@ struct LibraryPlayListView: View {
                         let title = "보관함 플레이리스트"
                         NavigationLink(
                             destination:
-                                PlayListView(id: 0)
+                                PlayListView(viewModel: .init(id: 0))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlist(id: 0),
                                                componentId: .playlistRow)

--- a/MiniVibe/MiniVibe/Views/Library/LibraryPlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryPlayListView.swift
@@ -52,7 +52,8 @@ struct LibraryPlayListView: View {
                         let title = "보관함 플레이리스트"
                         NavigationLink(
                             destination:
-                                PlayListView(viewModel: .init(id: 0))
+                                PlayListView(viewModel: .init(id: 0,
+                                                              eventLogger: eventLogger))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlist(id: 0),
                                                componentId: .playlistRow)

--- a/MiniVibe/MiniVibe/Views/Library/LibrarySongsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibrarySongsView.swift
@@ -34,13 +34,11 @@ struct LibrarySongsView: View {
                             }
                         }
                         ForEach(0..<50) { _ in
-                            let title = "너랑 나"
-                            let artist = "아이유"
-                            TrackRowC(track: trackinfo) {
+                            TrackRowC(viewModel: .init(track: trackinfo)) { _ in
                                 isMenuOpen = true
                             }
                             .fullScreenCover(isPresented: $isMenuOpen) {
-                                PlayerMenu(track: trackinfo)
+                                PlayerMenu(viewModel: .init(track: trackinfo))
                                     .logTransition(eventLogger: eventLogger,
                                                    identifier: .playerMenu(id: trackinfo.id),
                                                    componentId: .trackMenuButton

--- a/MiniVibe/MiniVibe/Views/Library/LibrarySongsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibrarySongsView.swift
@@ -34,11 +34,11 @@ struct LibrarySongsView: View {
                             }
                         }
                         ForEach(0..<50) { _ in
-                            TrackRowC(viewModel: .init(track: trackinfo)) { _ in
+                            TrackRowC(viewModel: .init(track: trackinfo, eventLogger: eventLogger)) { _ in
                                 isMenuOpen = true
                             }
                             .fullScreenCover(isPresented: $isMenuOpen) {
-                                PlayerMenu(viewModel: .init(track: trackinfo))
+                                PlayerMenu(viewModel: .init(track: trackinfo, eventLogger: eventLogger))
                                     .logTransition(eventLogger: eventLogger,
                                                    identifier: .playerMenu(id: trackinfo.id),
                                                    componentId: .trackMenuButton

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
@@ -31,7 +31,7 @@ struct PlayListSection<D: View>: View {
                     ForEach(playlists, id: \.id) { playlist in
                         NavigationLink(
                             destination:
-                                PlayListView(id: playlist.id)
+                                PlayListView(viewModel: .init(id: playlist.id))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlist(id: playlist.id),
                                                componentId: .playlistItem(section: title))

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
@@ -31,7 +31,8 @@ struct PlayListSection<D: View>: View {
                     ForEach(playlists, id: \.id) { playlist in
                         NavigationLink(
                             destination:
-                                PlayListView(viewModel: .init(id: playlist.id))
+                                PlayListView(viewModel: .init(id: playlist.id,
+                                                              eventLogger: eventLogger))
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlist(id: playlist.id),
                                                componentId: .playlistItem(section: title))

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
@@ -68,7 +68,7 @@ struct PlayListView: View {
                     .fullScreenCover(isPresented: $viewModel.showSheet) {
                         switch viewModel.activeSheet {
                         case .playlist:
-                            PlayListMenu(playlist: playlist)
+                            PlayListMenu(viewModel: viewModel)
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlistMenu(id: playlist.id),
                                                componentId: .playlistMenuButton)
@@ -92,7 +92,7 @@ struct PlayListView: View {
     var trailingBarButtons: some View {
         HStack(spacing: 10) {
             Button {
-                
+                viewModel.send(.like)
             } label: {
                 Image(systemName: "heart")
             }
@@ -119,7 +119,7 @@ struct PlayListView: View {
 struct PlayListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            PlayListView(viewModel: .init(id: 0))
+            PlayListView(viewModel: .init(id: 0, eventLogger: EventLogger(persistentContainer: .init())))
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
@@ -46,7 +46,8 @@ struct PlayListView: View {
                                 ) {
                                     Section(header: PlayAndShuffle(width: geometry.size.width)) {
                                         ForEach(playlist.tracks ?? [], id: \.id) { track in
-                                            TrackRowC(viewModel: TrackViewModel(track: track)) {
+                                            TrackRowC(viewModel: TrackViewModel(track: track,
+                                                                                eventLogger: eventLogger)) {
                                                 viewModel.send(.showTrackMenu(info: $0))
                                             }
                                         }

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
@@ -8,13 +8,12 @@
 import SwiftUI
 
 struct PlayListView: View {
-    init(id: Int) {
-        self.id = id
+    init(viewModel: PlaylistViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
     
     @EnvironmentObject private var eventLogger: EventLogger
-    @StateObject private var viewModel = PlaylistViewModel()
-    private let id: Int
+    @StateObject private var viewModel: PlaylistViewModel
     
     var body: some View {
         if let playlist = viewModel.playlist {
@@ -47,8 +46,8 @@ struct PlayListView: View {
                                 ) {
                                     Section(header: PlayAndShuffle(width: geometry.size.width)) {
                                         ForEach(playlist.tracks ?? [], id: \.id) { track in
-                                            TrackRowC(track: track) {
-                                                viewModel.send(.showTrackMenu(info: track))
+                                            TrackRowC(viewModel: TrackViewModel(track: track)) {
+                                                viewModel.send(.showTrackMenu(info: $0))
                                             }
                                         }
                                     }
@@ -72,10 +71,10 @@ struct PlayListView: View {
                                 .logTransition(eventLogger: eventLogger,
                                                identifier: .playlistMenu(id: playlist.id),
                                                componentId: .playlistMenuButton)
-                        case let .track(info):
-                            PlayerMenu(track: info)
+                        case let .track(trackViewModel):
+                            PlayerMenu(viewModel: trackViewModel)
                                 .logTransition(eventLogger: eventLogger,
-                                               identifier: .playerMenu(id: info.id),
+                                               identifier: .playerMenu(id: trackViewModel.track.id),
                                                componentId: .trackMenuButton)
                         }
                     }
@@ -84,7 +83,7 @@ struct PlayListView: View {
         } else {
             Color.clear
                 .onAppear {
-                    viewModel.send(.appear(playlistID: id))
+                    viewModel.send(.appear)
                 }
         }
     }
@@ -119,7 +118,7 @@ struct PlayListView: View {
 struct PlayListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            PlayListView(id: 0)
+            PlayListView(viewModel: .init(id: 0))
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerControls.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerControls.swift
@@ -12,13 +12,13 @@ struct PlayerControls: View {
     @EnvironmentObject private var eventLogger: EventLogger
     @Binding var isOpenMenu: Bool
     @State private var isShuffle = false
-    let title: String
-    let artist: String
+    @ObservedObject var viewModel: TrackViewModel
     
     var body: some View {
+        let track = viewModel.track
         VStack {
-            PlayerSliderView(title: title,
-                             artist: artist,
+            PlayerSliderView(title: track.title,
+                             artist: track.artist.name,
                              isOpenMenu: $isOpenMenu)
                 .frame(height: 100)
             
@@ -49,21 +49,10 @@ struct PlayerControls: View {
                 Spacer()
                 
                 Button {
-                    if nowPlaying.playingTrack?.liked == 1 {
-                        nowPlaying.cancelLikedTrack(id: nowPlaying.playingTrack?.id ?? 0)
-                    } else {
-                        nowPlaying.likeTrack(id: nowPlaying.playingTrack?.id ?? 0)
-                    }
-                    
-                    // TO DO: action에서 분리해내기
-                    eventLogger.send(LikeLog(userId: 0,
-                                             componentId: "PlayerLikeButton",
-                                             data: .init(type: "Track",
-                                                         id: nowPlaying.playingTrack?.id ?? 0),
-                                             isLike: nowPlaying.playingTrack?.liked == 1))
+                    viewModel.like()
                 } label: {
-                    Image(systemName: nowPlaying.playingTrack?.liked == 1 ? "heart.fill" : "heart")
-                        .foregroundColor(nowPlaying.playingTrack?.liked == 1 ? .pink : .secondary)
+                    Image(systemName: track.liked == 1 ? "heart.fill" : "heart")
+                        .foregroundColor(track.liked == 1 ? .pink : .secondary)
                         .font(.system(size: 32))
                 }
                 
@@ -82,6 +71,6 @@ struct PlayerControls: View {
 
 struct PlayerControls_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerControls(isOpenMenu: .constant(false), title: "곰인형", artist: "린")
+        PlayerControls(isOpenMenu: .constant(false), viewModel: .init(track: trackinfo))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerControls.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerControls.swift
@@ -71,6 +71,6 @@ struct PlayerControls: View {
 
 struct PlayerControls_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerControls(isOpenMenu: .constant(false), viewModel: .init(track: trackinfo))
+        PlayerControls(isOpenMenu: .constant(false), viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerThumbnail.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerThumbnail.swift
@@ -13,13 +13,14 @@ struct PlayerThumbnail: View {
     @Binding var isOpenLyrics: Bool
     
     var body: some View {
+        let track = nowPlaying.playingTrack?.track
         VStack {
-            KFImage(URL(string: nowPlaying.playingTrack?.album.imageUrl ?? ""))
+            KFImage(URL(string: track?.album.imageUrl ?? ""))
                 .resizable()
                 .aspectRatio(1, contentMode: .fit)
                 .scaleEffect(nowPlaying.isPlaying ? 1 : 0.9)
             
-            Text(nowPlaying.playingTrack?.lyrics ?? "")
+            Text(track?.lyrics ?? "")
                 .font(.system(size: 14))
                 .foregroundColor(.secondary)
                 .lineLimit(2)

--- a/MiniVibe/MiniVibe/Views/Player/Lyrics.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Lyrics.swift
@@ -37,7 +37,7 @@ struct Lyrics: View {
             
             ZStack(alignment: .bottomTrailing) {
                 ScrollView {
-                    Text(nowPlaying.playingTrack?.lyrics ?? "")
+                    Text(nowPlaying.playingTrack?.track.lyrics ?? "")
                         .font(.system(size: CGFloat(15 * textSize.rawValue)))
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
@@ -60,7 +60,7 @@ struct Lyrics_Previews: PreviewProvider {
 struct BackgroundImage: View {
     @EnvironmentObject private var nowPlaying: NowPlaying
     var body: some View {
-        KFImage(URL(string: nowPlaying.playingTrack?.album.imageUrl ?? ""))
+        KFImage(URL(string: nowPlaying.playingTrack?.track.album.imageUrl ?? ""))
             .resizable()
             .scaledToFill()
             .overlay(Color.white.blur(radius: 300))
@@ -79,14 +79,14 @@ struct LyricsTrackInfo: View {
     
     var body: some View {
         HStack(spacing: 10) {
-            KFImage(URL(string: nowPlaying.playingTrack?.album.imageUrl ?? ""))
+            KFImage(URL(string: nowPlaying.playingTrack?.track.album.imageUrl ?? ""))
                 .resizable()
                 .scaledToFit()
             
             VStack(alignment: .leading) {
-                Text(nowPlaying.playingTrack?.album.title ?? "Unknown")
+                Text(nowPlaying.playingTrack?.track.album.title ?? "Unknown")
                     .font(.title3)
-                Text(nowPlaying.playingTrack?.artist.name ?? "Unknown")
+                Text(nowPlaying.playingTrack?.track.artist.name ?? "Unknown")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }

--- a/MiniVibe/MiniVibe/Views/Player/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Player.swift
@@ -24,7 +24,8 @@ struct Player: View {
             
             Spacer()
             
-            PlayerControls(isOpenMenu: $isMenuOpen, viewModel: nowPlaying.playingTrack ?? .init(track: trackinfo))
+            PlayerControls(isOpenMenu: $isMenuOpen,
+                           viewModel: nowPlaying.playingTrack ?? .init(track: trackinfo, eventLogger: eventLogger))
                 .environmentObject(nowPlaying)
             
             Spacer()

--- a/MiniVibe/MiniVibe/Views/Player/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Player.swift
@@ -19,17 +19,14 @@ struct Player: View {
             PlayerHeader(title: "오늘 Top 100")
             
             Spacer()
-
-            if let track = nowPlaying.playingTrack {
-                PlayerThumbnail(isOpenLyrics: $isLyricsOpen)
-                
-                Spacer()
-                
-                PlayerControls(isOpenMenu: $isMenuOpen,
-                               title: track.title,
-                               artist: track.artist.name)
-            }
-                
+            
+            PlayerThumbnail(isOpenLyrics: $isLyricsOpen)
+            
+            Spacer()
+            
+            PlayerControls(isOpenMenu: $isMenuOpen, viewModel: nowPlaying.playingTrack ?? .init(track: trackinfo))
+                .environmentObject(nowPlaying)
+            
             Spacer()
             
             footer
@@ -56,7 +53,7 @@ struct Player: View {
             .font(.system(size: 12))
             .logSubscription(eventLogger: eventLogger,
                              componentId: "")
-
+            
             Spacer()
             
             Button {

--- a/MiniVibe/MiniVibe/Views/Player/PlayerView.swift
+++ b/MiniVibe/MiniVibe/Views/Player/PlayerView.swift
@@ -12,7 +12,7 @@ struct PlayerView: View {
     @EnvironmentObject var eventLogger: EventLogger
     @State private var isOpenMenu = false
     @State private var isOpenLyrics = false
-
+    
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -36,7 +36,9 @@ struct PlayerView: View {
             }
             .animation(.easeInOut)
             .fullScreenCover(isPresented: $isOpenMenu) {
-                PlayerMenu(track: trackinfo)
+                if let viewModel = nowPlaying.playingTrack {
+                    PlayerMenu(viewModel: viewModel)
+                }
             }
         }
     }

--- a/MiniVibe/MiniVibe/Views/Player/UpNextList.swift
+++ b/MiniVibe/MiniVibe/Views/Player/UpNextList.swift
@@ -37,14 +37,14 @@ struct UpNextList: View {
             
             VStack(spacing: 0) {
                 List(selection: $nowPlaying.selectedTracks) {
-                    ForEach(nowPlaying.upNext, id: \.self) { track in
+                    ForEach(nowPlaying.upNext, id: \.self) { viewModel in
                         HStack(spacing: 10) {
-                            KFImage(URL(string: track.album.imageUrl))
+                            KFImage(URL(string: viewModel.track.album.imageUrl))
                                 .resizable()
                                 .frame(width: 50, height: 50)
                             VStack(alignment: .leading) {
-                                Text(track.title)
-                                Text(track.artist.name)
+                                Text(viewModel.track.title)
+                                Text(viewModel.track.artist.name)
                             }
                         }
                     }
@@ -95,7 +95,7 @@ struct UpNextList: View {
         let destinationIndex = sourceIndex < destination ?  destination - 1 : destination
         if sourceIndex != destinationIndex {
             eventLogger.send(MoveTrackLog(userId: 0,
-                                          trackId: nowPlaying.upNext[destinationIndex].id,
+                                          trackId: nowPlaying.upNext[destinationIndex].track.id,
                                           source: sourceIndex,
                                           destination: destinationIndex))
         }

--- a/MiniVibe/MiniVibe/Views/Search/Components/NewsItem.swift
+++ b/MiniVibe/MiniVibe/Views/Search/Components/NewsItem.swift
@@ -25,7 +25,8 @@ struct NewsItem: View {
             }
             
             NavigationLink(destination:
-                            AlbumView(viewModel: .init(id: news.albumId))
+                            AlbumView(viewModel: .init(id: news.albumId,
+                                                       eventLogger: eventLogger))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: news.albumId),
                                            componentId: .newsItem)

--- a/MiniVibe/MiniVibe/Views/Search/Components/NewsItem.swift
+++ b/MiniVibe/MiniVibe/Views/Search/Components/NewsItem.swift
@@ -25,7 +25,7 @@ struct NewsItem: View {
             }
             
             NavigationLink(destination:
-                            AlbumView(id: news.albumId)
+                            AlbumView(viewModel: .init(id: news.albumId))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: news.albumId),
                                            componentId: .newsItem)

--- a/MiniVibe/MiniVibe/Views/Today/MagazineView.swift
+++ b/MiniVibe/MiniVibe/Views/Today/MagazineView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MagazineView: View {
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject private var eventLogger: EventLogger
     let magazine: Magazine
     
     var body: some View {
@@ -28,7 +29,9 @@ struct MagazineView: View {
                             Text(ArticleExample.content)
                                 .padding(.horizontal, width * .paddingRatio)
                             ForEach(0..<10) { index in
-                                TrackRowE(viewModel: .init(track: trackinfo), order: index)
+                                TrackRowE(viewModel: .init(track: trackinfo,
+                                                           eventLogger: eventLogger),
+                                          order: index)
                             }
                         }
                         .padding(.horizontal, geometry.size.width * .paddingRatio)

--- a/MiniVibe/MiniVibe/Views/Today/MagazineView.swift
+++ b/MiniVibe/MiniVibe/Views/Today/MagazineView.swift
@@ -28,7 +28,7 @@ struct MagazineView: View {
                             Text(ArticleExample.content)
                                 .padding(.horizontal, width * .paddingRatio)
                             ForEach(0..<10) { index in
-                                TrackRowE(order: index, track: trackinfo)
+                                TrackRowE(viewModel: .init(track: trackinfo), order: index)
                             }
                         }
                         .padding(.horizontal, geometry.size.width * .paddingRatio)

--- a/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
@@ -25,7 +25,8 @@ struct RecommandedPlayListSection: View {
                 LazyHStack(spacing: width * .spacingRatio) {
                     ForEach(0..<5) { _ in
                         NavigationLink(destination:
-                                        AlbumView(viewModel: .init(id: 11))
+                                        AlbumView(viewModel: .init(id: 11,
+                                                                   eventLogger: eventLogger))
                                         .logTransition(eventLogger: eventLogger,
                                                        identifier: .album(id: 11),
                                                        componentId: .playlistItem(section: title))

--- a/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
@@ -25,7 +25,7 @@ struct RecommandedPlayListSection: View {
                 LazyHStack(spacing: width * .spacingRatio) {
                     ForEach(0..<5) { _ in
                         NavigationLink(destination:
-                                        AlbumView(id: 11)
+                                        AlbumView(viewModel: .init(id: 11))
                                         .logTransition(eventLogger: eventLogger,
                                                        identifier: .album(id: 11),
                                                        componentId: .playlistItem(section: title))


### PR DESCRIPTION
### 📕 Issue Number

Close #387 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] NowPlaying과 결합되어있던 메뉴 화면들 분리
- [x] 메뉴 화면에서 좋아요 버튼을 누르면 좋아요 요청, 이벤트 수집
- [x] 여러 화면에서의 트랙 정보를 동기화해주기 위해 TrackViewModel 생성, 모든 트랙의 정보는 ViewModel을 통해서만 관리
- [x] 여러곳에 분산되어있던 좋아요 이벤트 발생 지점을 ViewModel에서만 발생하도록 통일
- [x] 메뉴 화면에 단순 데이터를 전달하는것이 아닌, 뷰모델을 전달하도록 수정하여 메뉴 화면에서 변경한 데이터가 다른곳에도 적용되도록 수정

### 📘 작업 유형

- [x] 신규 기능 추가
- [x] 버그 수정


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>
