### PR TITLE
[iOS] 다크모드 지원 및 프리뷰 활용도 향상 #397

### DIFF
--- a/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
+++ b/MiniVibe/MiniVibe.xcodeproj/project.pbxproj
@@ -133,6 +133,11 @@
 		80ABC18D2574DFDE003D4666 /* UpNextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ABC18C2574DFDE003D4666 /* UpNextList.swift */; };
 		80C6207A256CF21600B5C375 /* StationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C62079256CF21600B5C375 /* StationItem.swift */; };
 		80C6207D256CFBA100B5C375 /* StationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6207C256CFBA100B5C375 /* StationSection.swift */; };
+		80C6CBC52585033200747FED /* View+ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6CBC42585033200747FED /* View+ColorScheme.swift */; };
+		80C6CBCA2585201100747FED /* TrackRowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6CBC92585201100747FED /* TrackRowInfo.swift */; };
+		80C6CBD02585207800747FED /* TrackRowImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6CBCF2585207800747FED /* TrackRowImage.swift */; };
+		80C6CBD92585354800747FED /* MenuAlbumImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6CBD82585354800747FED /* MenuAlbumImage.swift */; };
+		80C6CBDD2585379700747FED /* Color+CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6CBDC2585379700747FED /* Color+CustomColor.swift */; };
 		80D02E00257E0C6400A6748F /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D02DFF257E0C6400A6748F /* SearchViewModel.swift */; };
 		80D02E04257E0DD300A6748F /* SearchUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D02E03257E0DD300A6748F /* SearchUseCase.swift */; };
 		80D02E08257E0E0D00A6748F /* News.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D02E07257E0E0D00A6748F /* News.swift */; };
@@ -293,6 +298,11 @@
 		80ABC18C2574DFDE003D4666 /* UpNextList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpNextList.swift; sourceTree = "<group>"; };
 		80C62079256CF21600B5C375 /* StationItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationItem.swift; sourceTree = "<group>"; };
 		80C6207C256CFBA100B5C375 /* StationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSection.swift; sourceTree = "<group>"; };
+		80C6CBC42585033200747FED /* View+ColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ColorScheme.swift"; sourceTree = "<group>"; };
+		80C6CBC92585201100747FED /* TrackRowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackRowInfo.swift; sourceTree = "<group>"; };
+		80C6CBCF2585207800747FED /* TrackRowImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackRowImage.swift; sourceTree = "<group>"; };
+		80C6CBD82585354800747FED /* MenuAlbumImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuAlbumImage.swift; sourceTree = "<group>"; };
+		80C6CBDC2585379700747FED /* Color+CustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+CustomColor.swift"; sourceTree = "<group>"; };
 		80D02DFF257E0C6400A6748F /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		80D02E03257E0DD300A6748F /* SearchUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUseCase.swift; sourceTree = "<group>"; };
 		80D02E07257E0E0D00A6748F /* News.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = News.swift; sourceTree = "<group>"; };
@@ -357,8 +367,8 @@
 				8065E4B9257728AF007F5990 /* Menu */,
 				8065E4C72577298C007F5990 /* Components */,
 				8084AB6C256E403900F2AAC2 /* ThumbnailRow.swift */,
-				445919A3256E4A6F0069DAB2 /* ThumbnailGridView.swift */,
 				44139CBA25763C5F000CEEA5 /* ThumbnailGrid.swift */,
+				445919A3256E4A6F0069DAB2 /* ThumbnailGridView.swift */,
 				8084AB6F256E409B00F2AAC2 /* ThumbnailList.swift */,
 				4478F71F256E89EB00755656 /* ChartList.swift */,
 				8087AC7A256F3E4D001F6369 /* PlayerPreview.swift */,
@@ -448,6 +458,8 @@
 				4478F716256E817100755656 /* CGFloat+Constant.swift */,
 				80A5215B25793A3E0051A925 /* View+dismissKeyboard.swift */,
 				448A39F72581476B00583624 /* Date+timeStampFormat.swift */,
+				80C6CBC42585033200747FED /* View+ColorScheme.swift */,
+				80C6CBDC2585379700747FED /* Color+CustomColor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -480,6 +492,7 @@
 		8004801425779A3D0055F5BB /* TrackRows */ = {
 			isa = PBXGroup;
 			children = (
+				80C6CBC82585200400747FED /* Components */,
 				805E28D2256BDC4A007AF5F1 /* TrackRowA.swift */,
 				80DA952025779FE9008C9DFF /* TrackRowB.swift */,
 				80DA95242577A084008C9DFF /* TrackRowC.swift */,
@@ -618,6 +631,7 @@
 		8065E4B9257728AF007F5990 /* Menu */ = {
 			isa = PBXGroup;
 			children = (
+				80C6CBD72585353600747FED /* Components */,
 				44139C80257607D3000CEEA5 /* MenuButton.swift */,
 				440D023525779C4F00477A7D /* MenuThumbnailButton.swift */,
 				440D02392577A3E500477A7D /* MenuCloseButton.swift */,
@@ -732,6 +746,23 @@
 				80ABC1822574C1FC003D4666 /* NetworkError+Equatable.swift */,
 			);
 			path = MiniVibeTests;
+			sourceTree = "<group>";
+		};
+		80C6CBC82585200400747FED /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				80C6CBC92585201100747FED /* TrackRowInfo.swift */,
+				80C6CBCF2585207800747FED /* TrackRowImage.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		80C6CBD72585353600747FED /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				80C6CBD82585354800747FED /* MenuAlbumImage.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		80D02E13257E119C00A6748F /* Components */ = {
@@ -924,7 +955,9 @@
 				802187E325828B79009A4D95 /* Engagement+CoreDataClass.swift in Sources */,
 				440F10952582693800FD3FF4 /* Like+CoreDataClass.swift in Sources */,
 				4474DC032574E6BC006FC827 /* PlayerThumbnail.swift in Sources */,
+				80C6CBDD2585379700747FED /* Color+CustomColor.swift in Sources */,
 				80A5214A257918FF0051A925 /* SearchBar.swift in Sources */,
+				80C6CBC52585033200747FED /* View+ColorScheme.swift in Sources */,
 				4478F71C256E858700755656 /* MixtapeGrid.swift in Sources */,
 				805E28D7256BDE90007AF5F1 /* SectionTitle.swift in Sources */,
 				80DA95332577A681008C9DFF /* TrackRowD.swift in Sources */,
@@ -961,6 +994,7 @@
 				80A5213B257902FF0051A925 /* LibraryAlbumsView.swift in Sources */,
 				44D5FAC6257FDE5D00A3E91C /* ArtistSectionViewModel.swift in Sources */,
 				444272B3256CDEC8008BB87B /* TodayTitle.swift in Sources */,
+				80C6CBD92585354800747FED /* MenuAlbumImage.swift in Sources */,
 				4474DBFD2574DF78006FC827 /* Player.swift in Sources */,
 				805E28D3256BDC4A007AF5F1 /* TrackRowA.swift in Sources */,
 				80C6207A256CF21600B5C375 /* StationItem.swift in Sources */,
@@ -991,6 +1025,7 @@
 				44139CB525763960000CEEA5 /* ArtistAlbumGridView.swift in Sources */,
 				80813997257E657A00A5B6AD /* MagazineView.swift in Sources */,
 				440F109C25826C6B00FD3FF4 /* LikeLog.swift in Sources */,
+				80C6CBD02585207800747FED /* TrackRowImage.swift in Sources */,
 				445D3A3F257FC46D0002D2DE /* MixtapeSection.swift in Sources */,
 				44A90ADD25822F420032CD82 /* EventLogType.swift in Sources */,
 				445D3A3B257FBF3D0002D2DE /* Mixtape.swift in Sources */,
@@ -1041,6 +1076,7 @@
 				44F9797C256D04EA00C9C224 /* RecommandedPlayListItem.swift in Sources */,
 				4474DC062574E8DB006FC827 /* PlayerSlider.swift in Sources */,
 				8033A7AA257FA7B100B1C321 /* NowPlaying.swift in Sources */,
+				80C6CBCA2585201100747FED /* TrackRowInfo.swift in Sources */,
 				444272BB256CE701008BB87B /* PreviewSection.swift in Sources */,
 				800FA84D257DC5EA008926A5 /* Albums.swift in Sources */,
 				806D272925812DA8002580B3 /* TrackUseCase.swift in Sources */,

--- a/MiniVibe/MiniVibe.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MiniVibe/MiniVibe.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
+        "state": {
+          "branch": null,
+          "revision": "2a10bf41da75599a9f8e872dbd44fe0155a2e00c",
+          "version": "5.15.8"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/MiniVibe/MiniVibe/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/MiniVibe/MiniVibe/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.362",
+          "green" : "0.004",
+          "red" : "0.999"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/MiniVibe/MiniVibe/Assets.xcassets/PlayAndShuffleColor.colorset/Contents.json
+++ b/MiniVibe/MiniVibe/Assets.xcassets/PlayAndShuffleColor.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.969",
+          "green" : "0.970",
+          "red" : "0.969"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.108",
+          "green" : "0.108",
+          "red" : "0.108"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MiniVibe/MiniVibe/Assets.xcassets/PreviewPlayerColor.colorset/Contents.json
+++ b/MiniVibe/MiniVibe/Assets.xcassets/PreviewPlayerColor.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.077",
+          "green" : "0.077",
+          "red" : "0.077"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MiniVibe/MiniVibe/Chart.swift
+++ b/MiniVibe/MiniVibe/Chart.swift
@@ -17,7 +17,6 @@ struct Chart: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
                         Text("차트")
-                            .foregroundColor(.black)
                             .font(.title)
                             .fontWeight(.heavy)
                             .padding(width * .paddingRatio)

--- a/MiniVibe/MiniVibe/Extensions/Color+CustomColor.swift
+++ b/MiniVibe/MiniVibe/Extensions/Color+CustomColor.swift
@@ -1,0 +1,16 @@
+//
+//  Color+CustomColor.swift
+//  MiniVibe
+//
+//  Created by Sue Cho on 2020/12/13.
+//
+
+import SwiftUI
+
+extension Color {
+    
+    static var playAndShuffle: Color {
+        return Color("PlayAndShuffleColor")
+    }
+    
+}

--- a/MiniVibe/MiniVibe/Extensions/View+ColorScheme.swift
+++ b/MiniVibe/MiniVibe/Extensions/View+ColorScheme.swift
@@ -1,0 +1,14 @@
+//
+//  View+ColorScheme.swift
+//  MiniVibe
+//
+//  Created by Sue Cho on 2020/12/12.
+//
+
+import SwiftUI
+
+extension View {
+    var previewInAllColorSchemes: some View {
+        ForEach(ColorScheme.allCases, id: \.self, content: preferredColorScheme)
+    }
+}

--- a/MiniVibe/MiniVibe/Library.swift
+++ b/MiniVibe/MiniVibe/Library.swift
@@ -32,10 +32,10 @@ struct Library: View {
             NavigationView {
                 VStack(alignment: .leading) {
                     Text("보관함")
-                        .foregroundColor(.black)
                         .font(.title)
                         .fontWeight(.heavy)
                         .padding(geometry.size.width * .paddingRatio)
+                    
                     Picker("Library", selection: $selection) {
                         ForEach(0..<categories.count) {
                             Text(categories[$0])
@@ -43,7 +43,9 @@ struct Library: View {
                     }
                     .pickerStyle(SegmentedPickerStyle())
                     .frame(height: 50)
+                    
                     Divider()
+                    
                     TabView(selection: $selection) {
                         LibrarySongsView().tag(0)
                             .animation(nil)

--- a/MiniVibe/MiniVibe/MainTab.swift
+++ b/MiniVibe/MiniVibe/MainTab.swift
@@ -50,7 +50,7 @@ struct MainTab: View {
                 }
                 .tag(ViewIdentifier.none)
         }
-        .accentColor(.accentColor)
+        .foregroundColor(.accentColor)
         .onPreferenceChange(Size.self, perform: { value in
             contentFrame = value.last ?? .zero
         })

--- a/MiniVibe/MiniVibe/MainTab.swift
+++ b/MiniVibe/MiniVibe/MainTab.swift
@@ -50,7 +50,7 @@ struct MainTab: View {
                 }
                 .tag(ViewIdentifier.none)
         }
-        .accentColor(.pink)
+        .accentColor(.accentColor)
         .onPreferenceChange(Size.self, perform: { value in
             contentFrame = value.last ?? .zero
         })

--- a/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumSection.swift
@@ -45,7 +45,7 @@ struct AlbumSection<D: View>: View {
                             }
                         )
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                 }
                 .padding(.horizontal, width * .paddingRatio)
             }

--- a/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
+++ b/MiniVibe/MiniVibe/Views/Album/AlbumView.swift
@@ -132,7 +132,7 @@ struct AlbumView: View {
             .padding(.vertical)
         }
         .font(.system(size: 17))
-        .foregroundColor(.black)
+        .foregroundColor(.primary)
     }
     
 }

--- a/MiniVibe/MiniVibe/Views/Artist/ArtistAlbumGridView.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/ArtistAlbumGridView.swift
@@ -22,7 +22,7 @@ struct ArtistAlbumGridView: View {
                              rightSegmentState: .normal,
                              barMetrics: .default)
         UISegmentedControl.appearance()
-            .setTitleTextAttributes([.foregroundColor: UIColor.black,
+            .setTitleTextAttributes([.foregroundColor: UIColor(Color.primary),
                                      .font: UIFont.boldSystemFont(ofSize: 16)],
                                     for: .selected)
         UISegmentedControl.appearance()

--- a/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/ArtistView.swift
@@ -99,7 +99,7 @@ struct ArtistView: View {
             } label: { Image(systemName: "ellipsis")  }
         }
         .font(.system(size: 17))
-        .foregroundColor(.black)
+        .foregroundColor(.primary)
     }
 }
 

--- a/MiniVibe/MiniVibe/Views/Artist/Components/ArtistItem.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/Components/ArtistItem.swift
@@ -20,6 +20,7 @@ struct ArtistItem: View {
             
             Text(artist.name)
                 .font(.system(size: 17))
+                .foregroundColor(.primary)
                 .lineLimit(2)
             
             Text("♥︎ 999")

--- a/MiniVibe/MiniVibe/Views/Artist/Components/ArtistItem.swift
+++ b/MiniVibe/MiniVibe/Views/Artist/Components/ArtistItem.swift
@@ -20,8 +20,8 @@ struct ArtistItem: View {
             
             Text(artist.name)
                 .font(.system(size: 17))
-                .foregroundColor(.black)
                 .lineLimit(2)
+            
             Text("♥︎ 999")
                 .font(.system(size: 12))
                 .foregroundColor(.secondary)

--- a/MiniVibe/MiniVibe/Views/Common/ChartList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartList.swift
@@ -38,7 +38,7 @@ struct ChartList: View {
                         
                         Image(systemName: "checkmark.circle")
                             .font(.system(size: 17))
-                            .foregroundColor(.black)
+                            .foregroundColor(.primary)
                     }
                 )
                 .padding(.bottom, 70)

--- a/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ChartSections/ChartSectionB.swift
@@ -16,13 +16,12 @@ struct ChartSectionB: View {
         VStack {
             SectionTitle(width: width, title: sectionTitle) {
                 ChartList(title: sectionTitle, tracks: [])
-                    .logTransition(eventLogger: eventLogger,
-                                   identifier: .chart(id: 0),
-                                   componentId: .sectionTitle(category: sectionTitle))
+//                    .logTransition(eventLogger: eventLogger,
+//                                   identifier: .chart(id: 0),
+//                                   componentId: .sectionTitle(category: sectionTitle))
             }
             
             ScrollView(.horizontal, showsIndicators: false) {
-                // 무조건 100개
                 LazyHGrid(rows: .init(repeating: .init(.flexible(minimum: 60)), count: 5)) {
                     ForEach(0..<100) { index in
                         TrackRowE(viewModel: .init(track: trackinfo,
@@ -41,5 +40,6 @@ struct ChartSectionB_Previews: PreviewProvider {
     static var previews: some View {
         ChartSectionB(width: 375, sectionTitle: "국내 급상승 🔥")
             .previewLayout(.fixed(width: 375, height: 420))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Components/PlayAndShuffle.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Components/PlayAndShuffle.swift
@@ -20,10 +20,10 @@ struct PlayAndShuffle: View {
                     Text("PLAY")
                 }
                 .padding()
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .frame(width: width * .thumbnailRatio)
             }
-            .background(Color.secondary.opacity(0.15))
+            .background(Color.playAndShuffle)
             .clipShape(RoundedRectangle(cornerRadius: 5))
             
             Button {
@@ -34,13 +34,12 @@ struct PlayAndShuffle: View {
                     Text("SHUFFLE")
                 }
                 .padding()
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .frame(width: width * .thumbnailRatio)
             }
-            .background(Color.secondary.opacity(0.15))
+            .background(Color.playAndShuffle)
             .clipShape(RoundedRectangle(cornerRadius: 5))
         }
-        .background(Color.white)
     }
 }
 
@@ -48,5 +47,6 @@ struct PlayAndShuffle_Previews: PreviewProvider {
     static var previews: some View {
         PlayAndShuffle(width: 375)
             .previewLayout(.fixed(width: 375, height: 80))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Components/PlaylistAlbumInfo.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Components/PlaylistAlbumInfo.swift
@@ -45,7 +45,7 @@ struct PlaylistAlbumInfo: View {
                     // TO DO: 앨범 전체 곡 다운로드
                 } label: {
                     Image(systemName: "arrow.down.to.line")
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                         .font(.system(size: 25, weight: .light))
                 }
             }
@@ -76,6 +76,8 @@ struct PlaylistAlbumInfo: View {
 
 struct PlaylistAlbumInfo_Previews: PreviewProvider {
     static var previews: some View {
-        PlaylistAlbumInfo(isOpenArticle: .constant(false), imageURL: "", title: "", subtitle: "", description: "", article: "")
+        PlaylistAlbumInfo(isOpenArticle: .constant(false), imageURL: "", title: "title", subtitle: "subtitle", description: "asdfasdfasdfasdf", article: "asdfasdfasdfasdf")
+            .previewLayout(.fixed(width: 375, height: 200))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Components/SectionTitle.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Components/SectionTitle.swift
@@ -24,7 +24,7 @@ struct SectionTitle<D: View>: View {
             label: {
                 HStack {
                     Text(title)
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                         .font(.system(size: 16.5))
                         .bold()
                     
@@ -35,7 +35,8 @@ struct SectionTitle<D: View>: View {
                         .font(.system(size: 12))
                 }
                 .padding(.horizontal, width * .paddingRatio)
-            })
+            }
+        )
     }
 }
 
@@ -44,6 +45,7 @@ struct SectionTitle_Previews: PreviewProvider {
         SectionTitle(width: 375, title: "최근 들은 노래") {
             Text("Hello")
         }
+        .previewInAllColorSchemes
         .previewLayout(.fixed(width: 375, height: 50))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Components/ThumbnailItem.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Components/ThumbnailItem.swift
@@ -21,6 +21,7 @@ struct ThumbnailItem: View {
             
             Text(title)
                 .font(.system(size: 17))
+                .foregroundColor(.primary)
             
             Text(subtitle)
                 .font(.system(size: 12))

--- a/MiniVibe/MiniVibe/Views/Common/Menu/ArtistMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/ArtistMenu.swift
@@ -16,10 +16,7 @@ struct ArtistMenu: View {
         VStack(spacing: 36) {
             Spacer()
             HStack {
-                KFImage(URL(string: artist.imageUrl))
-                    .resizable()
-                    .aspectRatio(1, contentMode: .fit)
-                    .frame(width: 80)
+                MenuAlbumImage(imageUrl: artist.imageUrl)
                     .clipShape(Circle())
                 
                 VStack(alignment: .leading,
@@ -35,7 +32,7 @@ struct ArtistMenu: View {
                 
                 Spacer()
             }
-            .foregroundColor(.black)
+            .foregroundColor(.primary)
             .padding(.horizontal)
             
             MenuButton(type: .like(0)) {
@@ -56,6 +53,6 @@ struct ArtistMenu: View {
 
 struct ArtistMenu_Previews: PreviewProvider {
     static var previews: some View {
-        ArtistMenu(artist: .init(id: 0, name: "", imageUrl: "", genre: .init(name: ""), tracks: [], albums: []))
+        ArtistMenu(artist: .init(id: 0, name: "보아", imageUrl: "", genre: .init(name: ""), tracks: [], albums: []))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/Components/MenuAlbumImage.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/Components/MenuAlbumImage.swift
@@ -1,0 +1,20 @@
+//
+//  MenuAlbumImage.swift
+//  MiniVibe
+//
+//  Created by Sue Cho on 2020/12/13.
+//
+
+import SwiftUI
+import KingfisherSwiftUI
+
+struct MenuAlbumImage: View {
+    let imageUrl: String
+    
+    var body: some View {
+        KFImage(URL(string: imageUrl))
+            .resizable()
+            .aspectRatio(1, contentMode: .fit)
+            .frame(width: 80)
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuButton.swift
@@ -77,13 +77,13 @@ struct MenuButton: View {
         } label: {
             HStack(spacing: 0) {
                 Image(systemName: type.imageName)
-                    .foregroundColor(type == .like(1) ? .pink : .black)
+                    .foregroundColor(type == .like(1) ? .accentColor : .primary)
                     .font(.system(size: 24))
                     .frame(width: 24, height: 24)
                     .padding(.horizontal)
                 
                 Text(type.title)
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
             }
             .font(.system(size: 18))
             
@@ -95,5 +95,7 @@ struct MenuButton: View {
 struct MenuButton_Previews: PreviewProvider {
     static var previews: some View {
         MenuButton(type: .like(0), action: {})
+            .previewLayout(.fixed(width: 375, height: 80))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuCloseButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuCloseButton.swift
@@ -17,13 +17,16 @@ struct MenuCloseButton: View {
     var body: some View {
         VStack(spacing: 0) {
             Divider()
+            
             Button {
                 action()
             } label: {
                 Spacer()
+                
                 Text("닫기")
                     .foregroundColor(.secondary)
                     .font(.system(size: 18))
+                
                 Spacer()
             }
             .padding(.vertical)
@@ -34,5 +37,7 @@ struct MenuCloseButton: View {
 struct MenuCloseButton_Previews: PreviewProvider {
     static var previews: some View {
         MenuCloseButton(action: { })
+            .previewLayout(.fixed(width: 375, height: 80))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/MenuThumbnailButton.swift
@@ -14,12 +14,8 @@ struct MenuThumbnailButton: View {
     let subtitle: String
     
     var body: some View {
-
         HStack {
-            KFImage(URL(string: imageUrl))
-                .resizable()
-                .aspectRatio(1, contentMode: .fit)
-                .frame(width: 80)
+            MenuAlbumImage(imageUrl: imageUrl)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
@@ -30,17 +26,17 @@ struct MenuThumbnailButton: View {
             }
             .lineLimit(1)
             .padding(.horizontal, 8)
-
+            
             Spacer()
         }
-        .foregroundColor(.black)
         .padding(.horizontal)
     }
-    
 }
 
 struct MenuThumbnailButton_Previews: PreviewProvider {
     static var previews: some View {
-        MenuThumbnailButton(imageUrl: "", title: "", subtitle: "")
+        MenuThumbnailButton(imageUrl: "", title: "bbb", subtitle: "ccc")
+            .previewLayout(.fixed(width: 375, height: 80))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
+++ b/MiniVibe/MiniVibe/Views/Common/Menu/PlayerMenu.swift
@@ -43,6 +43,17 @@ struct PlayerMenu: View {
 
 struct PlayerMenu_Previews: PreviewProvider {
     static var previews: some View {
-        PlayerMenu(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())))
+        VStack(spacing: 36) {
+            Spacer()
+            MenuThumbnailButton(imageUrl: "", title: "마음", subtitle: "아이유")
+            MenuButton(type: .like(1)) {}
+            MenuButton(type: .like(0)) {}
+            MenuButton(type: .exclude) {}
+            MenuButton(type: .download(.music)) {}
+            MenuButton(type: .addToPlaylist) {}
+            MenuButton(type: .share) {}
+            MenuCloseButton {}
+        }
+        .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/MultiselectTabBar.swift
+++ b/MiniVibe/MiniVibe/Views/Common/MultiselectTabBar.swift
@@ -13,7 +13,7 @@ struct MultiselectTabBar: View {
     var body: some View {
         ZStack {
             Rectangle()
-                .foregroundColor(Color.pink)
+                .foregroundColor(.accentColor)
             
             HStack {
                 TabbarButton(type: .addToPlaylist) {

--- a/MiniVibe/MiniVibe/Views/Common/PlayerPreview.swift
+++ b/MiniVibe/MiniVibe/Views/Common/PlayerPreview.swift
@@ -52,7 +52,7 @@ struct PlayerPreview: View {
 
     private func previewControlIcons() -> some View {
         let emptyUpNext: Bool = nowPlaying.upNext.isEmpty
-        let iconColor: Color = emptyUpNext ? Color.secondary : Color.black
+        let iconColor: Color = emptyUpNext ? Color.secondary : .primary
             
         return HStack(spacing: 20) {
             Button {
@@ -60,7 +60,7 @@ struct PlayerPreview: View {
             } label: {
                 nowPlaying.isPlaying ? Image(systemName: "pause.fill") : Image(systemName: "play.fill")
             }
-            .foregroundColor(.black)
+            .foregroundColor(.primary)
             
             Button {
                 nowPlaying.playNextTrack()

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailGrid.swift
@@ -32,7 +32,7 @@ struct ThumbnailGrid: View {
                                               imageURL: album.imageUrl)
                             }
                         )
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                     }
                 }
                 .padding(.horizontal, geometry.size.width * .paddingRatio)
@@ -44,9 +44,7 @@ struct ThumbnailGrid: View {
 
 struct ThumbnailGrid_Previews: PreviewProvider {
     static var previews: some View {
-        NavigationView {
-            ThumbnailGrid(albums: [])
-        }
+        ThumbnailGrid(albums: [])
                 
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailList.swift
@@ -22,7 +22,7 @@ struct ThumbnailList: View {
             ScrollView {
                 LazyVGrid(columns: [.init()], alignment: .leading) {
                     buildList()
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                 }
                 .navigationBarTitle(
                     Text(navigationTitle),

--- a/MiniVibe/MiniVibe/Views/Common/ThumbnailRow.swift
+++ b/MiniVibe/MiniVibe/Views/Common/ThumbnailRow.swift
@@ -38,5 +38,6 @@ struct ThumbnailRow_Previews: PreviewProvider {
     static var previews: some View {
         ThumbnailRow(imageURL: "", title: "나만 없어 그 한정판 LP 레코드", subtitle: "2020-12-12")
             .previewLayout(.fixed(width: 375, height: 100))
+            .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/Components/TrackRowImage.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/Components/TrackRowImage.swift
@@ -1,0 +1,28 @@
+//
+//  TrackRowImage.swift
+//  MiniVibe
+//
+//  Created by Sue Cho on 2020/12/13.
+//
+
+import SwiftUI
+import KingfisherSwiftUI
+
+struct TrackRowImage: View {
+    let imageUrl: String
+    
+    var body: some View {
+        KFImage(URL(string: imageUrl))
+            .resizable()
+            .frame(width: 50, height: 50)
+            .border(Color.gray, width: 0.7)
+    }
+}
+
+struct TrackRowMenu: View {
+    var body: some View {
+        Image(systemName: "ellipsis")
+            .foregroundColor(.primary)
+            .padding()
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/Components/TrackRowInfo.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/Components/TrackRowInfo.swift
@@ -1,0 +1,77 @@
+//
+//  TrackRowInfoA.swift
+//  MiniVibe
+//
+//  Created by Sue Cho on 2020/12/13.
+//
+
+import SwiftUI
+
+struct TrackRowInfoA: View {
+    let order: Int
+    let title: String
+    let artist: String
+    
+    var body: some View {
+        HStack {
+            Text("\(order)")
+                .font(.title3)
+                .padding(.horizontal, 4)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Spacer()
+                Text(title)
+                    .font(.system(size: 17))
+                
+                Text(artist)
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+                
+                Spacer()
+            }
+            
+            Spacer()
+            
+        }
+        .foregroundColor(.primary)
+    }
+}
+
+struct TrackRowInfoB: View {
+    let title: String
+    let artist: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Spacer()
+            Text(title)
+                .font(.system(size: 17))
+                .foregroundColor(.primary)
+            
+            Text(artist)
+                .font(.system(size: 13))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+    }
+}
+
+struct TrackRowInfoC: View {
+    let order: Int
+    let title: String
+    
+    var body: some View {
+        HStack {
+            HStack {
+                Text("\(order)")
+                    .font(.title3)
+                    .bold()
+                    .padding(.horizontal, 4)
+                
+                Text(title)
+                    .font(.title3)
+            }
+            .padding(.vertical, 10)
+        }
+    }
+}

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowA.swift
@@ -11,8 +11,8 @@ import KingfisherSwiftUI
 struct TrackRowA: View {
     @EnvironmentObject private var eventLogger: EventLogger
     @EnvironmentObject private var nowPlaying: NowPlaying
-    @State private var isMenuOpen = false
     @StateObject private var viewModel: TrackViewModel
+    @State private var isMenuOpen = false
     private let order: Int
     
     init(viewModel: TrackViewModel, order: Int) {
@@ -23,47 +23,26 @@ struct TrackRowA: View {
     var body: some View {
         let track = viewModel.track
         HStack {
-            NavigationLink(destination:
-                            AlbumView(viewModel: .init(id: track.album.id,
-                                                       eventLogger: eventLogger))
+            NavigationLink(destination: AlbumView(viewModel: .init(id: track.album.id,
+                                                                   eventLogger: eventLogger))
                             .logTransition(eventLogger: eventLogger,
                                            identifier: .album(id: track.album.id),
-                                           componentId: .trackRowThumbnail)
-            ) {
-                KFImage(URL(string: track.album.imageUrl))
-                    .resizable()
-                    .frame(width: 50, height: 50)
-                    .border(Color.gray, width: 0.7)
+                                           componentId: .trackRowThumbnail)) {
+                TrackRowImage(imageUrl: track.album.imageUrl)
             }
             
             Button {
                 nowPlaying.addTrack(track: viewModel)
             } label: {
-                Text("\(order)")
-                    .font(.title3)
-                    .padding(.horizontal, 4)
-                    .foregroundColor(.black)
-                
-                VStack(alignment: .leading, spacing: 4) {
-                    Spacer()
-                    Text(track.title)
-                        .font(.system(size: 17))
-                        .foregroundColor(.black)
-                    
-                    Text(track.artist.name)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
-                Spacer()
+                TrackRowInfoA(order: order,
+                              title: track.title,
+                              artist: track.artist.name)
             }
             
             Button {
                 isMenuOpen = true
             } label: {
-                Image(systemName: "ellipsis")
-                    .foregroundColor(.black)
-                    .padding()
+                TrackRowMenu()
             }
         }
         .fullScreenCover(isPresented: $isMenuOpen) {
@@ -74,7 +53,12 @@ struct TrackRowA: View {
 
 struct TrackRow_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowA(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), order: 3)
-            .previewLayout(.fixed(width: 375, height: 80))
+        HStack {
+            TrackRowImage(imageUrl: "")
+            TrackRowInfoA(order: 1, title: "마음", artist: "아이유")
+            TrackRowMenu()
+        }
+        .previewLayout(.fixed(width: 375, height: 80))
+        .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowB.swift
@@ -27,26 +27,13 @@ struct TrackRowB: View {
                                             identifier: .album(id: track.album.id),
                                             componentId: .trackRowThumbnail)
             ) {
-                KFImage(URL(string: track.album.imageUrl))
-                    .resizable()
-                    .frame(width: 50, height: 50)
-                    .border(Color.gray, width: 0.7)
+                TrackRowImage(imageUrl: track.album.imageUrl)
             }
             
             Button {
                 nowPlaying.addTrack(track: viewModel)
             } label: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Spacer()
-                    Text(track.title)
-                        .font(.system(size: 17))
-                        .foregroundColor(.black)
-                        
-                    Text(track.artist.name)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
+                TrackRowInfoB(title: track.title, artist: track.artist.name)
                 Spacer()
             }
         }
@@ -55,7 +42,12 @@ struct TrackRowB: View {
 
 struct TrackRowB_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowB(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())))
-            .previewLayout(.fixed(width: 375, height: 80))
+        HStack {
+            TrackRowImage(imageUrl: "")
+            TrackRowInfoB(title: "붉은 노을", artist: "이문세")
+            Spacer()
+        }
+        .previewLayout(.fixed(width: 375, height: 80))
+        .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowC.swift
@@ -29,35 +29,21 @@ struct TrackRowC: View {
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)
             ) {
-                KFImage(URL(string: viewModel.track.album.imageUrl))
-                    .resizable()
-                    .frame(width: 50, height: 50)
-                    .border(Color.gray, width: 0.7)
+                TrackRowImage(imageUrl: viewModel.track.album.imageUrl)
             }
             
             Button {
                 nowPlaying.addTrack(track: viewModel)
             } label: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Spacer()
-                    Text(viewModel.track.title)
-                        .font(.system(size: 17))
-                        .foregroundColor(.black)
-                        
-                    Text(viewModel.track.artist.name)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
+                TrackRowInfoB(title: viewModel.track.title,
+                              artist: viewModel.track.artist.name)
                 Spacer()
             }
             
             Button {
                 menuButtonAction(viewModel)
             } label: {
-                Image(systemName: "ellipsis")
-                    .foregroundColor(.black)
-                    .padding()
+                TrackRowMenu()
             }
         }
         .padding(.vertical, 8)
@@ -66,7 +52,13 @@ struct TrackRowC: View {
 
 struct TrackRowC_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowC(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), menuButtonAction: { _ in })
-            .previewLayout(.fixed(width: 375, height: 80))
+        HStack {
+            TrackRowImage(imageUrl: "")
+            TrackRowInfoB(title: "이문세", artist: "붉은 노을")
+            Spacer()
+            TrackRowMenu()
+        }
+        .previewLayout(.fixed(width: 375, height: 80))
+        .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowD.swift
@@ -24,18 +24,7 @@ struct TrackRowD: View {
             Button {
                 nowPlaying.addTrack(track: viewModel)
             } label: {
-                HStack {
-                    HStack {
-                        Text("\(order)")
-                            .font(.title3)
-                            .bold()
-                            .padding(.horizontal, 4)
-                        
-                        Text(viewModel.track.title)
-                            .font(.title3)
-                    }
-                    .padding(.vertical, 10)
-                }
+                TrackRowInfoC(order: order, title: viewModel.track.title)
             }
             
             Spacer()
@@ -47,14 +36,22 @@ struct TrackRowD: View {
             }
             .padding()
         }
-        .foregroundColor(.black)
+        .foregroundColor(.primary)
         .padding(.vertical, 8)
     }
 }
 
 struct TrackRowD_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowD(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), order: 1, menuButtonAction: { _ in })
-            .previewLayout(.fixed(width: 375, height: 80))
+        HStack {
+            TrackRowInfoC(order: 1, title: "How You Like That")
+            Spacer()
+            Image(systemName: "ellipsis")
+                .padding()
+        }
+        .foregroundColor(.primary)
+        .padding(.vertical, 8)
+        .previewLayout(.fixed(width: 375, height: 80))
+        .previewInAllColorSchemes
     }
 }

--- a/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
+++ b/MiniVibe/MiniVibe/Views/Common/TrackRows/TrackRowE.swift
@@ -29,32 +29,15 @@ struct TrackRowE: View {
                                            identifier: .album(id: track.album.id),
                                            componentId: .trackRowThumbnail)
             ) {
-                KFImage(URL(string: track.album.imageUrl))
-                    .resizable()
-                    .frame(width: 50, height: 50)
-                    .border(Color.gray, width: 0.7)
+                TrackRowImage(imageUrl: track.album.imageUrl)
             }
             
             Button {
                 nowPlaying.addTrack(track: viewModel)
             } label: {
-                Text("\(order)")
-                    .font(.title3)
-                    .padding(.horizontal, 4)
-                    .foregroundColor(.black)
-                
-                VStack(alignment: .leading, spacing: 4) {
-                    Spacer()
-                    Text(track.title)
-                        .font(.system(size: 17))
-                        .foregroundColor(.black)
-                    
-                    Text(track.artist.name)
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
-                Spacer()
+                TrackRowInfoA(order: order,
+                               title: track.title,
+                               artist: track.artist.name)
             }
         }
     }
@@ -62,7 +45,12 @@ struct TrackRowE: View {
 
 struct TrackRowE_Previews: PreviewProvider {
     static var previews: some View {
-        TrackRowE(viewModel: .init(track: trackinfo, eventLogger: EventLogger(persistentContainer: .init())), order: 3)
-            .previewLayout(.fixed(width: 375, height: 80))
+        HStack {
+            TrackRowImage(imageUrl: "")
+            TrackRowInfoA(order: 3, title: "마음", artist: "아이유(IU)")
+        }
+        .previewLayout(.fixed(width: 375, height: 80))
+        .previewInAllColorSchemes
+            
     }
 }

--- a/MiniVibe/MiniVibe/Views/Library/LibraryAlbumsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryAlbumsView.swift
@@ -24,7 +24,7 @@ struct LibraryAlbumsView: View {
                             Image(systemName: "arrow.up.arrow.down")
                             Text("Recently Added")
                         }
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                     }
                 }
                 LazyVGrid(
@@ -45,7 +45,7 @@ struct LibraryAlbumsView: View {
                                 ThumbnailItem(title: title, subtitle: subtitle, imageURL: "")
                             }
                         )
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                     }
                 }
                 .padding(.bottom, 70)

--- a/MiniVibe/MiniVibe/Views/Library/LibraryArtistRow.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryArtistRow.swift
@@ -17,8 +17,10 @@ struct LibraryArtistRow: View {
                 .aspectRatio(1, contentMode: .fit)
                 .frame(width: 60)
                 .clipShape(Circle())
+            
             Text(artist)
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
+            
             Spacer()
         }
     }

--- a/MiniVibe/MiniVibe/Views/Library/LibraryArtistsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryArtistsView.swift
@@ -38,16 +38,17 @@ struct LibraryArtistsView: View {
                                 }
                             }
                         }
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                         
                         HStack {
                             Image(systemName: "plus")
                                 .font(.system(size: 30, weight: .ultraLight))
                                 .frame(width: 60, height: 60)
-                                .background(Color.secondary.opacity(0.3))
+                                .background(Color.playAndShuffle)
                                 .clipShape(Circle())
+                            
                             Text("아티스트 추가")
-                                .foregroundColor(.black)
+                            
                             Spacer()
                         }
                         
@@ -82,7 +83,7 @@ struct LibraryArtistsView: View {
                 .foregroundColor(.purple)
                 .frame(width: width * .thumbnailRatio)
             })
-            .background(Color.secondary.opacity(0.15))
+            .background(Color.playAndShuffle)
             .clipShape(RoundedRectangle(cornerRadius: 5))
             
             Button(action: {}, label: {
@@ -95,11 +96,9 @@ struct LibraryArtistsView: View {
                 .foregroundColor(.blue)
                 .frame(width: width * .thumbnailRatio)
             })
-            .background(Color.secondary.opacity(0.15))
+            .background(Color.playAndShuffle)
             .clipShape(RoundedRectangle(cornerRadius: 5))
         }
-        .background(Color.white)
-        
     }
 }
 

--- a/MiniVibe/MiniVibe/Views/Library/LibraryPlayListRow.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryPlayListRow.swift
@@ -23,8 +23,9 @@ struct LibraryPlayListRow: View {
             
             VStack(alignment: .leading) {
                 Text(title)
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                     .font(.system(size: 17))
+                
                 Text("10곡")
                     .foregroundColor(.secondary)
                     .font(.system(size: 14))

--- a/MiniVibe/MiniVibe/Views/Library/LibraryPlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibraryPlayListView.swift
@@ -37,7 +37,7 @@ struct LibraryPlayListView: View {
                             }
                         }
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                     
                     HStack(spacing: 24) {
                         Image(systemName: "plus")

--- a/MiniVibe/MiniVibe/Views/Library/LibrarySongsView.swift
+++ b/MiniVibe/MiniVibe/Views/Library/LibrarySongsView.swift
@@ -30,7 +30,7 @@ struct LibrarySongsView: View {
                                     Image(systemName: "arrow.up.arrow.down")
                                     Text("Recently Added")
                                 }
-                                .foregroundColor(.black)
+                                .foregroundColor(.primary)
                             }
                         }
                         ForEach(0..<50) { _ in

--- a/MiniVibe/MiniVibe/Views/Mixtape/MixtapeGrid.swift
+++ b/MiniVibe/MiniVibe/Views/Mixtape/MixtapeGrid.swift
@@ -30,7 +30,6 @@ struct MixtapeGrid: View {
                                               imageURL: mixtape.imageUrl)
                             }
                         )
-                        .foregroundColor(.black)
                     }
                 }
                 .padding(.horizontal, geometry.size.width * .paddingRatio)
@@ -38,16 +37,6 @@ struct MixtapeGrid: View {
             }
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
-            .navigationBarItems(
-                trailing: Button {
-                    
-                } label: {
-                    Text("취향 설정")
-                        .foregroundColor(.black)
-                        .font(.system(size: 16))
-                        .fontWeight(.regular)
-                }
-            )
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Mixtape/MixtapeSection.swift
+++ b/MiniVibe/MiniVibe/Views/Mixtape/MixtapeSection.swift
@@ -29,8 +29,10 @@ struct MixtapeSection: View {
                         NavigationLink(
                             destination:
                                 Text("MixtapeView")
-                                .logTransition(eventLogger: eventLogger, identifier: .mixtape(id: mixtape.id), componentId: ComponentId.mixtapeItem)
-                            ,
+                                .logTransition(eventLogger: eventLogger,
+                                               identifier: .mixtape(id: mixtape.id),
+                                               componentId: ComponentId.mixtapeItem
+                                ),
                             label: {
                                 ThumbnailItem(title: mixtape.title,
                                               subtitle: mixtape.subTitle,
@@ -39,7 +41,7 @@ struct MixtapeSection: View {
                             }
                         )
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                 }
                 .padding(.horizontal, width * .paddingRatio)
             }

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListSection.swift
@@ -45,7 +45,7 @@ struct PlayListSection<D: View>: View {
                             }
                         )
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                 }
                 .padding(.horizontal, width * .paddingRatio)
             }

--- a/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
+++ b/MiniVibe/MiniVibe/Views/PlayList/PlayListView.swift
@@ -111,7 +111,7 @@ struct PlayListView: View {
             .padding(.vertical)
         }
         .font(.system(size: 17))
-        .foregroundColor(.black)
+        .foregroundColor(.primary)
     }
     
 }

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerControls.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerControls.swift
@@ -41,7 +41,7 @@ struct PlayerControls: View {
                     nowPlaying.isPlaying.toggle()
                 } label: {
                     Image(systemName: nowPlaying.isPlaying ? "pause.fill" : "play.fill")
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                         .font(.system(size: 40))
                         .frame(height: 40)
                 }
@@ -52,7 +52,7 @@ struct PlayerControls: View {
                     viewModel.like()
                 } label: {
                     Image(systemName: track.liked == 1 ? "heart.fill" : "heart")
-                        .foregroundColor(track.liked == 1 ? .pink : .secondary)
+                        .foregroundColor(track.liked == 1 ? .accentColor : .secondary)
                         .font(.system(size: 32))
                 }
                 
@@ -62,7 +62,7 @@ struct PlayerControls: View {
                     isShuffle.toggle()
                 } label: {
                     Image(systemName: "shuffle")
-                        .foregroundColor(isShuffle ? .pink : .secondary)
+                        .foregroundColor(isShuffle ? .accentColor : .secondary)
                 }
             }
         }

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerHeader.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerHeader.swift
@@ -16,7 +16,6 @@ struct PlayerHeader: View {
                 
             } label: {
                 Image(systemName: "slider.horizontal.3")
-                    .foregroundColor(.black)
             }
             
             Spacer()
@@ -29,9 +28,9 @@ struct PlayerHeader: View {
                 
             } label: {
                 Image(systemName: "chevron.compact.down")
-                    .foregroundColor(.black)
             }
         }
+        .foregroundColor(.primary)
         .padding(8)
     }
 }

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerSlider.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerSlider.swift
@@ -29,7 +29,7 @@ struct PlayerSlider: View {
                     .foregroundColor(.secondary)
                 
                 Rectangle()
-                    .foregroundColor(.pink)
+                    .foregroundColor(.accentColor)
                     .frame(width: width * CGFloat(percentage / 100))
             }
             .frame(height: dragAction ? 24 : 3)

--- a/MiniVibe/MiniVibe/Views/Player/Components/PlayerSliderView.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/PlayerSliderView.swift
@@ -49,7 +49,7 @@ struct PlayerSliderView: View {
                     isOpenMenu = true
                 } label: {
                     Image(systemName: "ellipsis")
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                 }
             }
         }

--- a/MiniVibe/MiniVibe/Views/Player/Components/RepeatButton.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Components/RepeatButton.swift
@@ -41,7 +41,7 @@ struct RepeatButton: View {
             type.next()
         } label: {
             Image(systemName: type.imageName)
-                .foregroundColor(type == .none ? .secondary : .pink)
+                .foregroundColor(type == .none ? .secondary : .accentColor)
         }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Player/Lyrics.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Lyrics.swift
@@ -39,6 +39,7 @@ struct Lyrics: View {
                 ScrollView {
                     Text(nowPlaying.playingTrack?.track.lyrics ?? "")
                         .font(.system(size: CGFloat(15 * textSize.rawValue)))
+                        .foregroundColor(.black)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                 }
@@ -49,12 +50,6 @@ struct Lyrics: View {
         .background(BackgroundImage())
     }
     
-}
-
-struct Lyrics_Previews: PreviewProvider {
-    static var previews: some View {
-        Lyrics(isOpenLyrics: .constant(false))
-    }
 }
 
 struct BackgroundImage: View {
@@ -96,7 +91,7 @@ struct LyricsTrackInfo: View {
             Button {
                 action()
             } label: { Image(systemName: "xmark") }
-            .foregroundColor(.black)
+            .foregroundColor(.primary)
         }
         .frame(height: 50)
         .padding(.horizontal, 20)
@@ -119,5 +114,13 @@ struct LyricsViewOption: View {
         .padding()
         .font(.system(size: 25))
         .foregroundColor(.black)
+    }
+}
+
+struct Lyrics_Previews: PreviewProvider {
+    static var previews: some View {
+        //Lyrics(isOpenLyrics: .constant(false))
+        LyricsViewOption(textSize: .constant(.one))
+            .previewLayout(.fixed(width: 300, height: 80))
     }
 }

--- a/MiniVibe/MiniVibe/Views/Player/Player.swift
+++ b/MiniVibe/MiniVibe/Views/Player/Player.swift
@@ -50,7 +50,7 @@ struct Player: View {
                 Text("미리듣기 중")
                 Image(systemName: "info.circle")
             }
-            .foregroundColor(.pink)
+            .foregroundColor(.accentColor)
             .font(.system(size: 12))
             .logSubscription(eventLogger: eventLogger,
                              componentId: "")

--- a/MiniVibe/MiniVibe/Views/Player/UpNextList.swift
+++ b/MiniVibe/MiniVibe/Views/Player/UpNextList.swift
@@ -34,6 +34,7 @@ struct UpNextList: View {
                 trailingBarItem
             }
             .padding()
+            .foregroundColor(.primary)
             
             VStack(spacing: 0) {
                 List(selection: $nowPlaying.selectedTracks) {
@@ -44,7 +45,12 @@ struct UpNextList: View {
                                 .frame(width: 50, height: 50)
                             VStack(alignment: .leading) {
                                 Text(viewModel.track.title)
+                                    .font(.system(size: 13))
+                                    .foregroundColor(.primary)
+                                
                                 Text(viewModel.track.artist.name)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.secondary)
                             }
                         }
                     }

--- a/MiniVibe/MiniVibe/Views/Profile/Article.swift
+++ b/MiniVibe/MiniVibe/Views/Profile/Article.swift
@@ -25,7 +25,7 @@ struct Article: View {
                     isOpenArticle = false
                 } label: {
                     Image(systemName: "xmark")
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                         .font(.system(size: 17))
                 }
                 .padding(.vertical)
@@ -35,13 +35,16 @@ struct Article: View {
                     KFImage(URL(string: imageURL))
                         .resizable()
                         .aspectRatio(1, contentMode: .fit)
+                    
                     VStack(alignment: .leading, spacing: 4) {
                         Text(title)
                             .font(.system(size: 30, weight: .bold))
+                        
                         Text(subtitle)
                             .foregroundColor(.secondary)
                             .font(.system(size: 20))
                     }
+                    
                     Text(content)
                         .foregroundColor(.secondary)
                         .font(.system(size: 16))
@@ -62,11 +65,16 @@ struct Article: View {
 
 struct Article_Previews: PreviewProvider {
     static var previews: some View {
-        Article(isOpenArticle: .constant(true), imageURL: "", title: "Dynamite", subtitle: "방탄소년단", content: "asdf")
+        Article(isOpenArticle: .constant(true),
+                imageURL: "",
+                title: "Dynamite",
+                subtitle: "방탄소년단",
+                content: ArticleExample.content
+        )
+        .previewInAllColorSchemes
     }
 }
 
-// swiftlint:disable line_length
 enum ArticleExample {
     static let content =
         """
@@ -77,30 +85,6 @@ enum ArticleExample {
     그룹 방탄소년단이 8월 21일 디지털 싱글 <Dynamite>를 전 세계적으로 동시 발매한다.
 
     <Dynamite>는 밝고 경쾌한 분위기의 디스코 팝(Disco Pop) 장르로, 팬들을 위한 희망의 메시지를 담았다. 코로나19 사태가 야기한 무력감과 허탈감을 이겨낼 '돌파구'로서 방탄소년단은 데뷔 이래 처음으로 영어로 곡을 소화하는 새로운 도전에 나섰다.
-
-    올해 데뷔 7주년을 맞은 방탄소년단은 지난 2월 21일 발표한 정규 4집 <MAP OF THE SOUL : 7>에서 시련과 상처, 두려움 등 자신들의 진솔한 이야기를 노래로 표현했다. '보여주고 싶은 나'와 '외면하고 싶은 나'를 받아들이고 '온전한 나'를 찾은 방탄소년단이 <Dynamite>에 담은 메시지는 바로 '행복'과 '자신감'이다. 그리고 그 행복과 자신감은 지금 모두에게 필요한 '에너지'의 원천이다. Jonas Brothers의 <What A Man Gotta Do?>, Hailee Steinfeld의 <I Love You's>를 만든 뮤지션 데이비드 스튜어트(David Stewart), 제시카 아곰바르(Jessica Agombar)가 작사·작곡에 참여해 흥겹고 발랄한 디스코풍 음악을 완성했다.
-
-    <Dynamite>는 앨범을 낼 때마다 자신들의 이야기로 전 세계인으로부터 공감을 이끌어 내는 방탄소년단이 모두에게 선사하는 '힐링송'이다. 자신들이 가장 잘하고 좋아하는 일인 춤과 노래로 사람들을 즐겁게 하는 것, 모두를 행복하게 만드는 데에서 방탄소년단 스스로도 행복을 찾게 된다는, '선순환의 고리'를 엿볼 수 있다.
-
-    "Light it up"
-    바로 지금, 방탄소년단이 들려 주고 싶은 노래
-
-    중독성 강한 신나는 리듬에, 유쾌하면서 역동적인 퍼포먼스를 더한 <Dynamite>. 여기에 "힘든 상황이지만 각자 할 수 있는 것들을 하자. 춤과 노래를 통해 자유와 행복을 찾자"라는 메시지까지 담은, 또 하나의 방탄소년단만의 음악이 탄생했다.
-
-    가사는 소소한 일상의 순간순간을 통해 삶의 소중함과 인생의 특별함을 얘기한다. 그 무엇도 계획대로 되지 않고, 시간이 멈춰 버린 것만 같으며, 큰 소리로 웃어 본 게 언제인지 아득하고, 누군가의 힘찬 응원을 바라는, 마치 달리다가 넘어진 것 같은 기분을 느끼는 모든 이들에게 바치는 곡이다. 무겁지 않게 유쾌한 언어로 풀어 내, 듣는 사람들의 입가에 저절로 미소가 번진다.
-
-    "Life is Dynamite"
-    '대체 불가' 방탄소년단의 퍼포먼스
-
-    방탄소년단은 <MAP OF THE SOUL : 7>의 타이틀곡 <ON>을 통해 30여 명의 댄서, 마칭 밴드(marching band)와 대규모 퍼포먼스를 구현해 독보적인 존재감을 보여 주었다. <Dynamite>에서는 빛나는 존재감을 드러내는 카리스마와 더불어 위트도 장착했다.
-
-    안무는 곡의 분위기와 어울리는 세련되고 경쾌한 느낌을 준다. 멤버마다 고유의 멋과 개성을 보여 줄 수 있는 퍼포먼스로 매력을 극대화한 것이 포인트. 누구나 따라 할 수 있는, 중독성 강한 안무라는 점도 특징이다. 단순한 동작을 연결해, 멤버들이 노래에 집중하면서 각자 자신의 매력을 가감 없이 표현할 수 있도록 짜여졌다. 한 사람씩 주인공이 된 듯 스포트라이트가 맞춰지는 순간은 화려한 쇼 뮤지컬을 보는 듯 하다.
-
-    뮤직비디오는 멜로디와 가사의 흥겨운 분위기를 살린 활기찬 콘셉트로, 여유롭게 음악을 즐기는 방탄소년단을 그린다. 처음부터 끝까지 에너지 넘치는 분위기 속에 방탄소년단의 밝고 쾌활한 일상을 엿볼 수 있도록 연출됐다. 멤버별 경쾌한 퍼포먼스가 흐르고, 후반부에는 화려한 배경과 역동적인 군무가 펼쳐져 보는 즐거움이 배가된다.
-
-    발매사, 기획사 정보를 제공하는 표
-    발매사    Dreamus
-    기획사    빅히트엔터테인먼트
     """
 }
 // swiftlint:enable line_length

--- a/MiniVibe/MiniVibe/Views/Search/Components/NewsItem.swift
+++ b/MiniVibe/MiniVibe/Views/Search/Components/NewsItem.swift
@@ -17,11 +17,12 @@ struct NewsItem: View {
         VStack(alignment: .trailing, spacing: width * .spacingRatio) {
             VStack {
                 KFImage(URL(string: news.imageUrl))
-                    .aspectRatio(3, contentMode: .fit)
-                
+                    .frame(width: width * .sectionRatio, height: 150)
+                    
                 Text(news.title)
                     .font(.system(size: 17))
                     .bold()
+                    .padding()
             }
             
             NavigationLink(destination:
@@ -36,12 +37,11 @@ struct NewsItem: View {
                     Text("음악듣기")
                         .font(.system(size: 13))
                 }
-                .foregroundColor(.pink)
+                .foregroundColor(.accentColor)
                 .padding()
             }
         }
         .border(Color(.systemGray6), width: 1)
-        .frame(width: width * .sectionRatio)
     }
 }
 

--- a/MiniVibe/MiniVibe/Views/Search/GenreSection.swift
+++ b/MiniVibe/MiniVibe/Views/Search/GenreSection.swift
@@ -20,12 +20,12 @@ struct GenreItem: View {
                     .frame(width: 5, height: 40)
                     .foregroundColor(Color(.brown))
                 Text(title)
+                    .foregroundColor(.primary)
             }
         }
-        .foregroundColor(.black)
         .frame(width: width * .thumbnailRatio, alignment: .leading)
         .padding(.vertical, 5)
-        .background(Color(.systemGray6))
+        .background(Color.playAndShuffle)
         .cornerRadius(3.0)
     }
 }
@@ -35,7 +35,6 @@ struct GenreSection: View {
         GeometryReader { geometry in
             VStack(alignment: .leading) {
                 Text("Genre")
-                    .foregroundColor(.black)
                     .font(.system(size: 16.5))
                     .bold()
                     
@@ -43,11 +42,9 @@ struct GenreSection: View {
                     columns: .init(repeating: .init(), count: 2)
                 ) {
                     ForEach(0..<4) { _ in
-                        // Navigation link 안 걸었어요. 또 한 depth 타고 들어가면... 무한...반..복ㅋㅋㅋ
                         GenreItem(title: "이 노래 들어봐", width: geometry.size.width)
                     }
                 }
-                .padding(.bottom, 70)
             }
             .padding(.horizontal, geometry.size.width * .paddingRatio)
         }
@@ -57,6 +54,5 @@ struct GenreSection: View {
 struct GenreSection_Previews: PreviewProvider {
     static var previews: some View {
         GenreSection()
-            
     }
 }

--- a/MiniVibe/MiniVibe/Views/Search/NewsSection.swift
+++ b/MiniVibe/MiniVibe/Views/Search/NewsSection.swift
@@ -16,6 +16,7 @@ struct NewsSection: View {
             HStack {
                 ForEach(newsList, id: \.id) { news in
                     NewsItem(width: width, news: news)
+                        .frame(width: width * .sectionRatio, height: 250)
                 }
             }
             .padding(.horizontal, width * .paddingRatio)

--- a/MiniVibe/MiniVibe/Views/Search/SearchBar.swift
+++ b/MiniVibe/MiniVibe/Views/Search/SearchBar.swift
@@ -36,7 +36,7 @@ struct SearchBar: View {
                     dismissKeyboard()
                 } label: { Text("취소") }
                 .padding(.trailing, 10)
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .transition(.move(edge: .trailing))
                 .animation(.easeInOut(duration: 0.2))
             }

--- a/MiniVibe/MiniVibe/Views/Search/SearchView.swift
+++ b/MiniVibe/MiniVibe/Views/Search/SearchView.swift
@@ -15,19 +15,20 @@ struct SearchView: View {
         GeometryReader { geometry in
             let width = geometry.size.width
             NavigationView {
-                VStack(alignment: .leading) {
-                    Text("검색")
-                        .foregroundColor(.black)
-                        .font(.title)
-                        .fontWeight(.heavy)
-                        .padding(geometry.size.width * .paddingRatio)
-                    
-                    SearchBar(searchedText: $searchedText, width: width)
-                    
-                    NewsSection(width: width,
-                                newsList: viewModel.newsList)
-                    
-                    GenreSection()
+                ScrollView {
+                    VStack(alignment: .leading) {
+                        Text("검색")
+                            .font(.title)
+                            .fontWeight(.heavy)
+                            .padding(geometry.size.width * .paddingRatio)
+                        
+                        SearchBar(searchedText: $searchedText, width: width)
+                        
+                        NewsSection(width: width,
+                                    newsList: viewModel.newsList)
+                        
+                        GenreSection()
+                    }
                 }
                 .navigationBarHidden(true)
             }

--- a/MiniVibe/MiniVibe/Views/Today/Components/PreviewItem.swift
+++ b/MiniVibe/MiniVibe/Views/Today/Components/PreviewItem.swift
@@ -17,7 +17,7 @@ struct PreviewItem: View {
             Image("content")
                 .resizable()
             
-            VStack(spacing: 3) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text("연인을 위한 캐롤")
                     .font(.system(size: 17))
                     .bold()

--- a/MiniVibe/MiniVibe/Views/Today/Components/PreviewItem.swift
+++ b/MiniVibe/MiniVibe/Views/Today/Components/PreviewItem.swift
@@ -10,19 +10,19 @@ import SwiftUI
 struct PreviewItem: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("인기 플레이리스트")
+            Text("Haapy Christmas")
                 .font(.system(size: 12))
-                .foregroundColor(.pink)
+                .foregroundColor(.accentColor)
             
             Image("content")
                 .resizable()
             
             VStack(spacing: 3) {
-                Text("오랜만에 흥 터지네")
+                Text("연인을 위한 캐롤")
                     .font(.system(size: 17))
                     .bold()
                 
-                Text("다들 들썩거릴 준비됐나요")
+                Text("너와 함께라면 하나도 춥지 않아")
                     .font(.system(size: 12))
                     .foregroundColor(.secondary)
             }

--- a/MiniVibe/MiniVibe/Views/Today/MagazineView.swift
+++ b/MiniVibe/MiniVibe/Views/Today/MagazineView.swift
@@ -44,7 +44,7 @@ struct MagazineView: View {
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 20))
-                        .foregroundColor(Color.black.opacity(0.8))
+                        .foregroundColor(Color.primary.opacity(0.8))
                         .padding(10) 
                 }
                 

--- a/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
+++ b/MiniVibe/MiniVibe/Views/Today/RecommandedPlayListSection.swift
@@ -35,7 +35,7 @@ struct RecommandedPlayListSection: View {
                                 .frame(width: width * .sectionRatio)
                         }
                     }
-                    .foregroundColor(.black)
+                    .foregroundColor(.primary)
                 }
                 .padding(.horizontal, width * .paddingRatio)
             }

--- a/MiniVibe/MiniVibe/Views/Today/Today.swift
+++ b/MiniVibe/MiniVibe/Views/Today/Today.swift
@@ -91,6 +91,14 @@ struct Today: View {
 
 struct Today_Previews: PreviewProvider {
     static var previews: some View {
-        Today()
+        Group {
+            Today()
+                .previewDevice(PreviewDevice(rawValue: "iPhone SE"))
+                .previewDisplayName("iPhone SE")
+            
+            Today()
+                .previewDevice(PreviewDevice(rawValue: "iPhone 12 mini"))
+                .previewDisplayName("iPhone 12 mini")
+        }
     }
 }

--- a/MiniVibe/MiniVibe/Views/Today/TodayTitle.swift
+++ b/MiniVibe/MiniVibe/Views/Today/TodayTitle.swift
@@ -14,7 +14,7 @@ struct TodayTitle: View {
     var body: some View {
         HStack {
             Text("#내돈내듣 VIBE")
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .font(.title)
                 .fontWeight(.heavy)
                 .logSubscription(eventLogger: eventLogger,


### PR DESCRIPTION
### 📕 Issue Number

Close #397 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [X] 다크모드 지원을 위한 color asset 지정
- [X] 특정 색 보다 시스템 색 활용
- [X] 프리뷰로 모드 살피기, 다중 기기 프리뷰 활용


### 📘 작업 유형

- [x] 신규 기능 추가


### 📋 체크리스트

- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

