### PR TITLE
[FE&BE] 쿠키로 요청 보내도록 수정 & 플레이리스트 상세에서 유저 아이디 쓰도록 수정

### DIFF
--- a/client/pages/album/[id].tsx
+++ b/client/pages/album/[id].tsx
@@ -4,7 +4,7 @@ import TrackRowList from '@components/organisms/CardLists/TrackRowList';
 import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
-import { request } from '@utils/apis';
+import { requestByCookie } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
 import { page, contentType, dataType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
@@ -76,8 +76,8 @@ const Album = ({ albumData, trackData, relatedAlbumData }) => {
 
 export async function getServerSideProps(context) {
     const { id } = context.query;
-
-    const albumData = await request(`${apiUrl.album}/${id}`);
+    const { req, res } = context;
+    const albumData = await requestByCookie(req, res, `${apiUrl.album}/${id}`);
     const trackData = albumData?.tracks;
     const relatedAlbumData = albumData?.relatedAlbums;
 

--- a/client/pages/artist/[id].tsx
+++ b/client/pages/artist/[id].tsx
@@ -5,7 +5,7 @@ import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 import Text from '@components/atoms/Text';
-import { request } from '@utils/apis';
+import { requestByCookie } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
 import { page, contentType, dataType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
@@ -81,7 +81,8 @@ const Artist = ({ artistData, trackData }) => {
 
 export async function getServerSideProps(context) {
     const { id } = context.query;
-    const artistData = await request(apiUrl.artist + `/${id}`);
+    const { req, res } = context;
+    const artistData = await requestByCookie(req, res, apiUrl.artist + `/${id}`);
     const trackData = artistData?.tracks;
 
     if (!artistData) {

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -3,7 +3,7 @@ import MainMagazineCard from '@components/organisms/Cards/MainMagazineCard/MainM
 import CardListContainer from '@components/organisms/CardListContainer';
 import MagazineCardList from '@components/organisms/CardLists/MagazineList/MagazineList';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
-import { request } from '@utils/apis';
+import { requestByCookie, request } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
 import { page, contentType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
@@ -112,6 +112,13 @@ const Home = ({ Magazinesdata, Newsdata, Playlistdata, Albumdata }) => {
 };
 
 export async function getServerSideProps(context) {
+    const { req, res } = context;
+    // const [Magazinesdata, Newsdata, Playlistdata, Albumdata] = await Promise.all([
+    //     requestByCookie(req, res, apiUrl.magazine),
+    //     requestByCookie(req, res, apiUrl.news),
+    //     requestByCookie(req, res, apiUrl.playlist),
+    //     requestByCookie(req, res, apiUrl.album),
+    // ]);
     const [Magazinesdata, Newsdata, Playlistdata, Albumdata] = await Promise.all([
         request(apiUrl.magazine),
         request(apiUrl.news),

--- a/client/pages/magazine/[id].tsx
+++ b/client/pages/magazine/[id].tsx
@@ -7,7 +7,7 @@ import Button from '@components/atoms/Button';
 import TrackRowList from '@components/organisms/CardLists/TrackRowList';
 import ShuffleIcon from '@material-ui/icons/Shuffle';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
-import { request } from '@utils/apis';
+import { requestByCookie } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
 import { page, contentType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
@@ -176,8 +176,9 @@ const MagazineDetail = ({ magazineData }) => {
 
 export async function getServerSideProps(context) {
     const { id } = context.query;
+    const { req, res } = context;
 
-    const magazineData = await request(`${apiUrl.magazine}/${id}`);
+    const magazineData = await requestByCookie(req, res,`${apiUrl.magazine}/${id}`);
 
     if (!magazineData) {
         return {

--- a/client/pages/playlist/[id].tsx
+++ b/client/pages/playlist/[id].tsx
@@ -5,7 +5,7 @@ import TrackRowList from '@components/organisms/CardLists/TrackRowList';
 import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
-import { request } from '@utils/apis';
+import { requestByCookie } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
 import { page, contentType, dataType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
@@ -77,8 +77,8 @@ const Playlist = ({ playlistData, trackData, artistData }) => {
 
 export async function getServerSideProps(context) {
     const { id } = context.query;
-
-    const playlistData = await request(apiUrl.playlist + `/${id}`);
+    const { req, res } = context;
+    const playlistData = await requestByCookie(req, res, apiUrl.playlist + `/${id}`);
     const trackData = playlistData?.tracks;
     const artistData = playlistData?.relatedArtists;
 

--- a/client/pages/this-month.tsx
+++ b/client/pages/this-month.tsx
@@ -4,7 +4,7 @@ import TrackRowList from '@components/organisms/CardLists/TrackRowList';
 import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
-import { request } from 'utils/apis';
+import { requestByCookie } from 'utils/apis';
 import apiUrl from 'constants/apiUrl';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 import { contentType, dataType, page } from '@constants/identifier';
@@ -77,7 +77,8 @@ const ThisMonth = ({ PlaylistData, TrackData }) => {
 };
 
 export async function getServerSideProps(context) {
-    const PlaylistData = await request(apiUrl.playlist + `/9`);
+    const { req, res } = context;
+    const PlaylistData = await requestByCookie(req, res, apiUrl.playlist + `/9`);
     const TrackData = PlaylistData?.tracks;
 
     // TODO: error handling

--- a/client/pages/track/[id].tsx
+++ b/client/pages/track/[id].tsx
@@ -4,7 +4,7 @@ import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 import Text from '@components/atoms/Text';
 import AlbumCard from '@components/organisms/Cards/AlbumCard/AlbumCard';
-import { request } from '@utils/apis';
+import { requestByCookie } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
 import { page, contentType, dataType } from '@constants/identifier';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
@@ -131,8 +131,8 @@ const Track = ({ trackData, belongAlbumData }) => {
 
 export async function getServerSideProps(context) {
     const { id } = context.query;
-
-    const trackData = await request(`${apiUrl.track}/${id}`);
+    const { req, res } = context;
+    const trackData = await requestByCookie(req, res, `${apiUrl.track}/${id}`);
     const belongAlbumData = { ...trackData?.album, artist: trackData?.artist };
 
     if (!trackData) {

--- a/client/utils/apis.js
+++ b/client/utils/apis.js
@@ -31,6 +31,7 @@ export const request = async (url, option) => {
         console.log(err);
     }
 };
+
 export const requestByCookie = async (req, res, apiUrl) => {
     const cookies = new Cookies(req, res);
     const data = await request(apiUrl, {
@@ -40,6 +41,7 @@ export const requestByCookie = async (req, res, apiUrl) => {
     });
     return data;
 };
+
 export const requestPlaylists = async (apiUrl) => {
     const { data } = await axios(apiUrl, {
         method: 'GET',
@@ -50,12 +52,17 @@ export const requestPlaylists = async (apiUrl) => {
     });
     return data.data;
 };
+
 export const addToLibrary = async (url, option) => {
     const options = { ...getRequestOptions('POST', option) };
     try {
         await axios({
             ...options,
             url,
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: getCookie('token'),
+            },
         });
     } catch (err) {
         console.error(err);

--- a/client/utils/apis.js
+++ b/client/utils/apis.js
@@ -59,10 +59,6 @@ export const addToLibrary = async (url, option) => {
         await axios({
             ...options,
             url,
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: getCookie('token'),
-            },
         });
     } catch (err) {
         console.error(err);

--- a/server/src/routes/playlists/playlists.controller.ts
+++ b/server/src/routes/playlists/playlists.controller.ts
@@ -21,8 +21,7 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
 
 const listById = async (req: Request, res: Response, next: NextFunction) => {
     const { id } = req.params;
-    // TODO: 인증 구현 후 수 정
-    const userId = 1;
+    const userId = req.user;
     try {
         const PlaylistRepository = getRepository(Playlist);
         const playlist = await PlaylistRepository.createQueryBuilder('playlist')


### PR DESCRIPTION
### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 작업 내역 1 플레이리스트 상세 api에 하드코딩된 아이디 지우고 req.user 사용하도록 변경
- [x] 작업 내역 2 필요한 페이지들에서 requestByCookie로 요청 보내도록 수정
- [x] 작업 내역 3 api 중 addToLibrary도 쿠키 담아서 요청 보내도록 수정
- [ ] 작업 내역 4


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 투데이에서 매거진과 뉴스 드롭다운으로 보관함에 추가하는 부분 아직도 안되는 것 같습니다.. 
1. 매거진에서 드롭다운으로 보관함에 추가 누르면 addToLibrary api로 연결된 플레이리스트 아이디 담아서 보내고, 
2. 뉴스에서 드롭다운으로 보관함에 추가 누르면 addToLibrary api로 연결된 앨범 아이디 담아서 보내야하는 걸로 알고 있는데 아마 중간에 뭐가 잘 안되는 것 같아요


- 특이 사항 2 유저의 좋아요 정보가 필요한 페이지들은 모두 requestByCookie로 수정했습니다. 그렇게 하고 나니까 로그인 안한 상태에서 requestByCookie로 요청 보내는 페이지 들어가면 그냥 404 뜨네요... 이부분도 수정해야 할 것 같아요

- 특이 사항 3 원래 구현해야 할 기능을 하나도 구현 못하고 있는 상황이라... 저는 여기까지만 손대고 원래 구현해야 할 기능들 구현하겠습니다.. 정혜님이 이어서 수정해주시면 좋을 것 같아요

- 특이 사항 4 쿠키 담아서 보내야 하는 api들이 좀 더 있는 것 같은데 아마 수정이 안된 부분들도 있는 것 같아요..확인 부탁드려요

<br/><br/>
