### PR TITLE
[FE] 각 페이지에서 보관함 저장(좋아요), 내 플레이리스트에 추가 에러 수정 

### DIFF
--- a/client/components/atoms/Button/AddButton.tsx
+++ b/client/components/atoms/Button/AddButton.tsx
@@ -2,13 +2,11 @@ import React, { MouseEvent, useState, useContext } from 'react';
 import styled from 'styled-components';
 import CheckIcon from '@material-ui/icons/Check';
 import AddIcon from '@material-ui/icons/Add';
-import ComponentInfoContext from '@utils/context/ComponentInfoContext';
-import apiUrl from '@constants/apiUrl';
-import { addToLibrary, deleteFromLibrary } from '@utils/apis';
 
 interface AddButtonProps {
     onClick?: (e: MouseEvent<HTMLElement>) => void;
     variant?: 'primary';
+    liked: boolean;
 }
 
 const Container = styled.div`
@@ -16,22 +14,11 @@ const Container = styled.div`
     margin-left: 10px;
 `;
 
-const AddButton = ({ onClick, variant }: AddButtonProps) => {
-    const [isClicked, setIsClicked] = useState(false);
-    const componentInfo = useContext(ComponentInfoContext);
-
-    const onClickHandler = () => {
-        if (isClicked) {
-            addToLibrary(`${apiUrl.libraryAlbum}`, { data: { id: componentInfo.data.id } });
-        } else {
-            deleteFromLibrary(`${apiUrl.libraryAlbum}/${componentInfo.data.id}`);
-        }
-        setIsClicked(!isClicked);
-    };
+const AddButton = ({ onClick, variant, liked }: AddButtonProps) => {
     return (
-        <Container onClick={onClickHandler}>
-            {isClicked && <AddIcon />}
-            {!isClicked && <CheckIcon />}
+        <Container onClick={onClick}>
+            {!liked && <AddIcon />}
+            {liked && <CheckIcon />}
         </Container>
     );
 };

--- a/client/components/atoms/Button/AddButton.tsx
+++ b/client/components/atoms/Button/AddButton.tsx
@@ -1,7 +1,10 @@
-import React, { MouseEvent, useState } from 'react';
+import React, { MouseEvent, useState, useContext } from 'react';
 import styled from 'styled-components';
 import CheckIcon from '@material-ui/icons/Check';
 import AddIcon from '@material-ui/icons/Add';
+import ComponentInfoContext from '@utils/context/ComponentInfoContext';
+import apiUrl from '@constants/apiUrl';
+import { addToLibrary, deleteFromLibrary } from '@utils/apis';
 
 interface AddButtonProps {
     onClick?: (e: MouseEvent<HTMLElement>) => void;
@@ -13,18 +16,24 @@ const Container = styled.div`
     margin-left: 10px;
 `;
 
-const AddButton = ({
-  onClick, variant
-}: AddButtonProps) => {
+const AddButton = ({ onClick, variant }: AddButtonProps) => {
     const [isClicked, setIsClicked] = useState(false);
+    const componentInfo = useContext(ComponentInfoContext);
+
     const onClickHandler = () => {
+        if (isClicked) {
+            addToLibrary(`${apiUrl.libraryAlbum}`, { data: { id: componentInfo.data.id } });
+        } else {
+            deleteFromLibrary(`${apiUrl.libraryAlbum}/${componentInfo.data.id}`);
+        }
         setIsClicked(!isClicked);
-    }
-    return(
-        <Container onClick = { onClickHandler }>
+    };
+    return (
+        <Container onClick={onClickHandler}>
             {isClicked && <AddIcon />}
             {!isClicked && <CheckIcon />}
         </Container>
-        )};
+    );
+};
 
 export default AddButton;

--- a/client/components/atoms/CheckBox/index.tsx
+++ b/client/components/atoms/CheckBox/index.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components';
 import { selectTrack, unselectTrack } from 'reducers/selectedTrack';
 import { TrackRowCardProps, CheckBoxProps } from 'interfaces/props';
 
-
-
 const StyledCheckBox = styled.div`
     width: 40px;
     padding: 10px 12px;
@@ -26,9 +24,9 @@ const Input = styled.input`
     }
     &:checked + label {
         background-image: linear-gradient(transparent, transparent),
-            url(https://vibe.naver.com/img/sp_vibe.7af837ac.svg);
-        background-size: 1118px 1081px;
-        background-position: -816px -860px;
+            url(https://vibe.naver.com/img/sp_vibe.463acaba.svg);
+        background-size: 1118px 1106px;
+        background-position: -97px -1086px;
         border: none;
     }
 `;
@@ -37,15 +35,16 @@ const CheckBox = ({ id, data }: CheckBoxProps) => {
     const [checked, setChecked] = useState(false);
 
     const onChangeHandler = () => {
-        setChecked((checked) => (!checked));
-        !checked? dispatch(selectTrack(data)):dispatch(unselectTrack(data.id));
-    }
+        setChecked((checked) => !checked);
+        !checked ? dispatch(selectTrack(data)) : dispatch(unselectTrack(data.id));
+    };
 
-    return(
+    return (
         <StyledCheckBox>
-            <Input type="checkbox" id ={`'${id}'`} checked = {checked} onChange = {onChangeHandler}/>
+            <Input type="checkbox" id={`'${id}'`} checked={checked} onChange={onChangeHandler} />
             <label htmlFor={`'${id}'`} />
         </StyledCheckBox>
-        )};
+    );
+};
 
 export default CheckBox;

--- a/client/components/atoms/Heart/Heart.tsx
+++ b/client/components/atoms/Heart/Heart.tsx
@@ -18,7 +18,7 @@ const Heart = ({ isSelected, sort, onClick }: HeartProps) => {
         setIsClicked(!isClicked);
     };
     return (
-        <Container onClick={onClickHandler}>
+        <Container onClick={sort === 'musicPlayer' ? onClickHandler : undefined}>
             {sort !== 'musicPlayer' ? (
                 <div onClick={onClick}>
                     {isSelected ? <FavoriteIcon style={{ color: '#FF1150' }} /> : <FavoriteBorderIcon />}

--- a/client/components/molecules/ContentsThumbnail/ContentsThumbnail.tsx
+++ b/client/components/molecules/ContentsThumbnail/ContentsThumbnail.tsx
@@ -67,7 +67,7 @@ const contentsDropDownMenu = [
     },
 ];
 
-const ContentsThumbnail = ({ src, href, sort }: ContentsThumbnailProps) => (
+const ContentsThumbnail = ({ src, href, sort, contentId }: ContentsThumbnailProps) => (
     <ThumbnailContainer>
         <StyledImage
             src={src}
@@ -83,7 +83,12 @@ const ContentsThumbnail = ({ src, href, sort }: ContentsThumbnailProps) => (
         />
         <ButtonContainer>
             <PlayButton />
-            <StyledDropDown id="contents" control={StyledMoreHorizIcon} menuItems={contentsDropDownMenu} state={{}} />
+            <StyledDropDown
+                id="contents"
+                control={StyledMoreHorizIcon}
+                menuItems={contentsDropDownMenu}
+                state={{ contentId }}
+            />
         </ButtonContainer>
     </ThumbnailContainer>
 );

--- a/client/components/molecules/DropdownMenu/index.tsx
+++ b/client/components/molecules/DropdownMenu/index.tsx
@@ -65,8 +65,9 @@ const DropdownMenu = ({ id, control: ControlComponent, menuItems, children, stat
                 data: [id],
             },
         };
-        addToPlaylist(url, reqBodyData);
-        removePlaylistModal();
+        addToPlaylist(url, reqBodyData).then((data) => {
+            removePlaylistModal();
+        });
     };
     return (
         <>

--- a/client/components/molecules/DropdownMenu/index.tsx
+++ b/client/components/molecules/DropdownMenu/index.tsx
@@ -49,17 +49,20 @@ const DropdownMenu = ({ id, control: ControlComponent, menuItems, children, stat
         });
     };
     const onClickHandler = (e) => {
-        let type = undefined;
-        if (componentInfo.data.type === 'magazine') type = 'playlist';
-        else if (componentInfo.data.type === 'news') type = 'album';
-        else type = componentInfo.data.type;
+        let type = componentInfo.data.type;
+        let id = componentInfo.data.id;
+        if (type === 'magazine' || type === 'news') {
+            id = state.contentId;
+            if (type === 'magazine') type = 'playlist';
+            else if (type === 'news') type = 'album';
+        }
 
         const playlistId = e.currentTarget.firstChild.innerText;
         const url = `${apiUrl.playlist}/${type}`;
         const reqBodyData = {
             data: {
                 id: parseInt(playlistId),
-                data: [componentInfo.data.id],
+                data: [id],
             },
         };
         addToPlaylist(url, reqBodyData);

--- a/client/components/organisms/Cards/NewsCard/NewsCard.tsx
+++ b/client/components/organisms/Cards/NewsCard/NewsCard.tsx
@@ -31,16 +31,16 @@ const StyledA = styled(A)`
     font-size: 16px;
 `;
 
-const NewsCard = ( data : NewsCardProps) => {
-    const {id, title, imageUrl, date, link, albumId} = data;
+const NewsCard = (data: NewsCardProps) => {
+    const { id, title, imageUrl, date, link, albumId } = data;
     return (
         <CardContainer>
             <ThumbnailContainer>
-                <ContentsThumbnail sort="news" src={imageUrl} href={"/album/"+albumId} />
+                <ContentsThumbnail sort="news" src={imageUrl} href={'/album/' + albumId} contentId={albumId} />
             </ThumbnailContainer>
             <TextContainer>
                 <TitleContainer>
-                    <StyledA href={"/album/"+albumId}>{title}</StyledA>
+                    <StyledA href={'/album/' + albumId}>{title}</StyledA>
                 </TitleContainer>
                 <DescriptionContainer>
                     <A href={link} variant="tertiary">
@@ -49,7 +49,7 @@ const NewsCard = ( data : NewsCardProps) => {
                 </DescriptionContainer>
             </TextContainer>
         </CardContainer>
-    )
+    );
 };
 
 export default NewsCard;

--- a/client/components/organisms/Cards/TrackRowCard/TrackRowCard.styles.tsx
+++ b/client/components/organisms/Cards/TrackRowCard/TrackRowCard.styles.tsx
@@ -60,8 +60,9 @@ const BackgroundImg = styled.div`
     &::after {
         content: '';
         background-image: linear-gradient(transparent, transparent),
-            url(https://vibe.naver.com/img/sp_vibe.7af837ac.svg);
-        background-size: 1118px 1081px;
+            url(https://vibe.naver.com/img/sp_vibe.463acaba.svg);
+        background-size: 1118px 1106px;
+        background-position: -33px -1057px;
         display: inline-block;
         width: 20px;
         height: 20px;
@@ -69,13 +70,13 @@ const BackgroundImg = styled.div`
 `;
 export const Mp3 = styled(BackgroundImg)`
     &::after {
-        background-position: -307px -860px;
+        background-position: -810px -890px;
         width: 30px;
     }
 `;
 export const ShowLyricButton = styled(BackgroundImg)`
     &::after {
-        background-position: -969px -986px;
+        background-position: -33px -1057px;
     }
 `;
 

--- a/client/components/organisms/DetailHeader/index.tsx
+++ b/client/components/organisms/DetailHeader/index.tsx
@@ -73,7 +73,6 @@ const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
     const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
     const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
-
     const onAddUpNextAndPlayHandler = () => {
         if (sort === 'track') {
             dispatch(addToUpNextAndPlay([data]));
@@ -108,9 +107,15 @@ const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
                 </TextContainer>
                 <ButtonContainer>
                     {sort === 'track' && (
-                        <HeaderButtonGroup sort="track" onAddUpNextHandler={onAddUpNextAndPlayHandler} />
+                        <HeaderButtonGroup
+                            sort="track"
+                            onAddUpNextHandler={onAddUpNextAndPlayHandler}
+                            liked={data.liked}
+                        />
                     )}
-                    {sort !== 'track' && <HeaderButtonGroup onAddUpNextHandler={onAddUpNextAndPlayHandler} />}
+                    {sort !== 'track' && (
+                        <HeaderButtonGroup onAddUpNextHandler={onAddUpNextAndPlayHandler} liked={data.liked} />
+                    )}
                 </ButtonContainer>
             </DetailContainer>
         </HeaderContainter>

--- a/client/components/organisms/HeaderButtonGroup/index.tsx
+++ b/client/components/organisms/HeaderButtonGroup/index.tsx
@@ -10,6 +10,10 @@ import AddButton from '@components/atoms/Button/AddButton';
 import Heart from '@components/atoms/Heart/Heart';
 
 import { HeaderButtonGroupProps } from 'interfaces/props';
+import { useContext, useState } from 'react';
+import { addToLibrary, deleteFromLibrary } from '@utils/apis';
+import apiUrl from '@constants/apiUrl';
+import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 
 const ButtonContainer = styled.div<HeaderButtonGroupProps>`
     width: ${(props) => (props.sort === 'track' ? '300px' : '480px')};
@@ -49,20 +53,44 @@ const contentsDropDownMenu = [
     },
 ];
 
-const HeaderButtonGroup = ({sort, onAddUpNextHandler}: HeaderButtonGroupProps) => {
+const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGroupProps) => {
+    const [addButton, setAddButton] = useState(liked);
+    const componentInfo = useContext(ComponentInfoContext);
+
+    const addButtonHandler = () => {
+        if (!addButton) {
+            addToLibrary(`${apiUrl.libraryAlbum}`, { data: { id: componentInfo.data.id } });
+        } else {
+            deleteFromLibrary(`${apiUrl.libraryAlbum}/${componentInfo.data.id}`);
+        }
+        setAddButton(!addButton);
+    };
     return (
-        <ButtonContainer sort={sort}>
-            { sort === 'track' && 
-            <Button variant = "primary" width='100' height='40' icon={PlayArrowIcon} onClick={onAddUpNextHandler}>재생</Button> }
-            { sort !== 'track' && 
-            <Button variant = "primary" width='130' height='40' icon={PlayArrowIcon} onClick={onAddUpNextHandler}>전체재생</Button>}
-            { sort !== 'track' && 
-            <Button width='130' height='40' icon={ShuffleIcon}>랜덤재생</Button>
-            }
-            <Button height='40'>MP3 구매</Button>
-            { sort !== 'track' && <AddButton />}
-            { sort === 'track' && <Heart isSelected = {false}/>}
-            <StyledDropDown id="contents" control={StyledMoreHorizIcon} menuItems={contentsDropDownMenu} state={{}} />
+        <ButtonContainer sort={sort} liked={liked}>
+            {sort === 'track' && (
+                <Button variant="primary" width="100" height="40" icon={PlayArrowIcon} onClick={onAddUpNextHandler}>
+                    재생
+                </Button>
+            )}
+            {sort !== 'track' && (
+                <Button variant="primary" width="130" height="40" icon={PlayArrowIcon} onClick={onAddUpNextHandler}>
+                    전체재생
+                </Button>
+            )}
+            {sort !== 'track' && (
+                <Button width="130" height="40" icon={ShuffleIcon}>
+                    랜덤재생
+                </Button>
+            )}
+            <Button height="40">MP3 구매</Button>
+            {sort !== 'track' && <AddButton onClick={addButtonHandler} liked={addButton} />}
+            {sort === 'track' && <Heart isSelected={false} />}
+            <StyledDropDown
+                id="contents"
+                control={StyledMoreHorizIcon}
+                menuItems={contentsDropDownMenu}
+                state={{ setAddButton }}
+            />
         </ButtonContainer>
     );
 };

--- a/client/components/organisms/HeaderButtonGroup/index.tsx
+++ b/client/components/organisms/HeaderButtonGroup/index.tsx
@@ -54,16 +54,17 @@ const contentsDropDownMenu = [
 ];
 
 const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGroupProps) => {
-    const [addButton, setAddButton] = useState(liked);
+    const [likeStatus, setLikeStatus] = useState(liked);
     const componentInfo = useContext(ComponentInfoContext);
+    const data = componentInfo.data;
 
-    const addButtonHandler = () => {
-        if (!addButton) {
-            addToLibrary(`${apiUrl.libraryAlbum}`, { data: { id: componentInfo.data.id } });
+    const likeHandler = () => {
+        if (!likeStatus) {
+            addToLibrary(`${apiUrl.like}${data.type}s`, { data: { id: data.id } });
         } else {
-            deleteFromLibrary(`${apiUrl.libraryAlbum}/${componentInfo.data.id}`);
+            deleteFromLibrary(`${apiUrl.like}${data.type}s/${data.id}`);
         }
-        setAddButton(!addButton);
+        setLikeStatus(!likeStatus);
     };
     return (
         <ButtonContainer sort={sort} liked={liked}>
@@ -83,13 +84,13 @@ const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGrou
                 </Button>
             )}
             <Button height="40">MP3 구매</Button>
-            {sort !== 'track' && <AddButton onClick={addButtonHandler} liked={addButton} />}
-            {sort === 'track' && <Heart isSelected={false} />}
+            {sort !== 'track' && <AddButton onClick={likeHandler} liked={likeStatus} />}
+            {sort === 'track' && <Heart isSelected={likeStatus} onClick={likeHandler} />}
             <StyledDropDown
                 id="contents"
                 control={StyledMoreHorizIcon}
                 menuItems={contentsDropDownMenu}
-                state={{ setAddButton }}
+                state={{ setLikeStatus }}
             />
         </ButtonContainer>
     );

--- a/client/components/organisms/HeaderButtonGroup/index.tsx
+++ b/client/components/organisms/HeaderButtonGroup/index.tsx
@@ -60,11 +60,22 @@ const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGrou
 
     const likeHandler = () => {
         if (!likeStatus) {
-            addToLibrary(`${apiUrl.like}${data.type}s`, { data: { id: data.id } });
+            addToLibrary(`${apiUrl.like}${data.type}s`, { data: { id: data.id } })
+                .then((data) => {
+                    setLikeStatus(!likeStatus);
+                })
+                .catch((err) => {
+                    console.log(err);
+                });
         } else {
-            deleteFromLibrary(`${apiUrl.like}${data.type}s/${data.id}`);
+            deleteFromLibrary(`${apiUrl.like}${data.type}s/${data.id}`)
+                .then((data) => {
+                    setLikeStatus(!likeStatus);
+                })
+                .catch((err) => {
+                    console.log(err);
+                });
         }
-        setLikeStatus(!likeStatus);
     };
     return (
         <ButtonContainer sort={sort} liked={liked}>

--- a/client/hooks/useDropDownAction.ts
+++ b/client/hooks/useDropDownAction.ts
@@ -41,7 +41,9 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                 break;
             case dropDownMenu.addToLibrary:
                 let type = undefined
-                if(data.type === 'magazine' || data.type === 'news') type = 'playlist'
+                console.log('---------', data)
+                if(data.type === 'magazine') type = 'playlist'
+                else if(data.type === 'news') type = 'album'
                 else type = data.type
                 addToLibrary(`${apiUrl.like}${type}s`, {data: {
                     id: data.id

--- a/client/hooks/useDropDownAction.ts
+++ b/client/hooks/useDropDownAction.ts
@@ -46,7 +46,7 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                 addToLibrary(`${apiUrl.like}${type}s`, {data: {
                     id: data.id
                 }});
-                state.setAddButton(true);
+                state.setLikeStatus(true);
                 logLikeEvent(true);
                 break;
             case dropDownMenu.addToUpNext:

--- a/client/hooks/useDropDownAction.ts
+++ b/client/hooks/useDropDownAction.ts
@@ -22,13 +22,16 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                     data: {
                         id: data.id
                     }
-                });
-                state.setIsLiked(1);
+                })
+                .then(data => {state.setIsLiked(1)})
+                .catch(err => {console.log(err); });
                 logLikeEvent(true);
                 break;
             case dropDownMenu.unlike:
-                deleteFromLibrary(`${apiUrl.like}${data.type}s/${data.id}`);
-                state.setIsLiked(0);
+                deleteFromLibrary(`${apiUrl.like}${data.type}s/${data.id}`)
+                .then(data => {state.setIsLiked(0);})
+                .catch(err => {console.log(err); });
+                
                 logLikeEvent(false);
                 break;
             case dropDownMenu.addToPlaylist:
@@ -37,7 +40,7 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                         visibility: true,
                         data: data,
                     });
-                });
+                }).catch(err => {console.log(err); });
                 break;
             case dropDownMenu.addToLibrary:
                 let type = data.type
@@ -47,8 +50,9 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                     if(type === 'magazine') type = 'playlist'
                     else if(type === 'news') type = 'album'
                 }
-                addToLibrary(`${apiUrl.like}${type}s`, {data: {id} });
-                if(state.setLikeStatus) state.setLikeStatus(true)
+                addToLibrary(`${apiUrl.like}${type}s`, {data: {id} })
+                .then(data => {if(state.setLikeStatus) state.setLikeStatus(true)})
+                .catch(err => {console.log(err); });
                 logLikeEvent(true);
                 break;
             case dropDownMenu.addToUpNext:

--- a/client/hooks/useDropDownAction.ts
+++ b/client/hooks/useDropDownAction.ts
@@ -40,14 +40,14 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                 });
                 break;
             case dropDownMenu.addToLibrary:
-                let type = undefined
-                console.log('---------', data)
-                if(data.type === 'magazine') type = 'playlist'
-                else if(data.type === 'news') type = 'album'
-                else type = data.type
-                addToLibrary(`${apiUrl.like}${type}s`, {data: {
-                    id: data.id
-                }});
+                let type = data.type
+                let id = data.id
+                if(type === 'magazine' || type === 'news') {
+                    id = state.contentId
+                    if(type === 'magazine') type = 'playlist'
+                    else if(type === 'news') type = 'album'
+                }
+                addToLibrary(`${apiUrl.like}${type}s`, {data: {id} });
                 if(state.setLikeStatus) state.setLikeStatus(true)
                 logLikeEvent(true);
                 break;

--- a/client/hooks/useDropDownAction.ts
+++ b/client/hooks/useDropDownAction.ts
@@ -46,6 +46,7 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                 addToLibrary(`${apiUrl.like}${type}s`, {data: {
                     id: data.id
                 }});
+                state.setAddButton(true);
                 logLikeEvent(true);
                 break;
             case dropDownMenu.addToUpNext:

--- a/client/hooks/useDropDownAction.ts
+++ b/client/hooks/useDropDownAction.ts
@@ -46,7 +46,7 @@ const useDropDownAction = ({ userId, setAnchorEl, state }) => {
                 addToLibrary(`${apiUrl.like}${type}s`, {data: {
                     id: data.id
                 }});
-                state.setLikeStatus(true);
+                if(state.setLikeStatus) state.setLikeStatus(true)
                 logLikeEvent(true);
                 break;
             case dropDownMenu.addToUpNext:

--- a/client/interfaces/props.ts
+++ b/client/interfaces/props.ts
@@ -168,6 +168,7 @@ export interface CheckBoxProps {
 export interface HeaderButtonGroupProps {
     sort?: 'track';
     onAddUpNextHandler?: any;
+    liked: boolean
 }
 
 export interface LyricModalProps {

--- a/client/interfaces/props.ts
+++ b/client/interfaces/props.ts
@@ -42,6 +42,7 @@ export interface ContentsThumbnailProps {
     src: string;
     href: string;
     sort?: 'news' | 'mainMagazine' | 'normalMagazine' | 'recommendPlaylist' | 'normalPlaylist' | 'todayMagazine';
+    contentId?: number | undefined
 }
 
 export interface MixtapeCardProps {
@@ -155,7 +156,7 @@ export interface DropdownMenuProps {
         handleClick?: (e: MouseEvent<HTMLElement>) => void;
     }[];
     children?: ReactNode;
-    state?: object;
+    state?: any
 }
 
 export interface CheckBoxProps {

--- a/client/pages/this-month.tsx
+++ b/client/pages/this-month.tsx
@@ -4,11 +4,12 @@ import TrackRowList from '@components/organisms/CardLists/TrackRowList';
 import ContentsButtonGroup from '@components/organisms/ContentsButtonGroup';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
-import { requestByCookie } from 'utils/apis';
+import { request, requestByCookie } from 'utils/apis';
 import apiUrl from 'constants/apiUrl';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 import { contentType, dataType, page } from '@constants/identifier';
 import ComponentInfoWrapper from '@utils/context/ComponentInfoWrapper';
+import { getTokenFromCtx } from '@utils/cookies';
 
 const Artistdata = Array(9).fill({
     id: 3,
@@ -77,10 +78,9 @@ const ThisMonth = ({ PlaylistData, TrackData }) => {
 };
 
 export async function getServerSideProps(context) {
-    const { req, res } = context;
-    const PlaylistData = await requestByCookie(req, res, apiUrl.playlist + `/9`);
+    const token = getTokenFromCtx(context);
+    const PlaylistData = await request(`${apiUrl.playlist}/9`, {}, token);
     const TrackData = PlaylistData?.tracks;
-
     // TODO: error handling
 
     return {

--- a/client/utils/apis.js
+++ b/client/utils/apis.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { getCookie } from 'utils/cookies';
 import apiUrl from 'constants/apiUrl';
+import { rejects } from 'assert';
 
 export const getRequestOptions = (method, options, headers) => ({
     method: method,
@@ -42,14 +43,20 @@ export const requestByCookie = async (apiUrl) => {
 };
 
 export const requestPlaylists = async (apiUrl) => {
-    const { data } = await axios(apiUrl, {
-        method: 'GET',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: getCookie('token'),
-        },
-    });
-    return data.data;
+    try {
+        const { data } = await axios(apiUrl, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: getCookie('token'),
+            },
+        });
+        return data.data;
+    } catch (err) {
+        alert('로그인이 필요한 서비스입니다!');
+        console.log(err);
+        rejects(new Error());
+    }
 };
 
 export const addToLibrary = async (url, option) => {
@@ -62,6 +69,7 @@ export const addToLibrary = async (url, option) => {
     } catch (err) {
         alert('로그인이 필요한 서비스입니다!');
         console.error(err);
+        rejects(new Error());
     }
 };
 
@@ -75,6 +83,7 @@ export const addToPlaylist = async (url, data) => {
     } catch (err) {
         alert('로그인이 필요한 서비스입니다!');
         console.error(err);
+        rejects(new Error());
     }
 };
 
@@ -88,6 +97,7 @@ export const deleteFromLibrary = async (url, option) => {
     } catch (err) {
         alert('로그인이 필요한 서비스입니다!');
         console.error(err);
+        rejects(new Error());
     }
 };
 
@@ -106,6 +116,7 @@ export const createPlaylist = async (data) => {
     } catch (err) {
         alert('로그인이 필요한 서비스입니다!');
         console.error(err);
+        rejects(new Error());
     }
 };
 export const sendEvent = async (eventData) => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,13 +16,12 @@ app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(passport.initialize());
-passportInit(passport);
-
 app.use(cors({
     origin: process.env.CLIENT_HOST,
     credentials: true,
 }));
+app.use(passport.initialize());
+passportInit(passport);
 
 app.use('/auth', authRouter);
 app.use('/api', apiRouter);

--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { getRepository } from 'typeorm';
-
+import User from '../../models/User';
 import Album from '../../models/Album';
 
 const list = async (req: Request, res: Response, next: NextFunction) => {
@@ -40,6 +40,12 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
             .where('album.id = :id', { id })
             .getOne();
 
+        const UserRepository = getRepository(User);
+        const userLiked = await UserRepository.createQueryBuilder('user')
+            .leftJoinAndSelect('user.libraryAlbums', 'library_albums')
+            .where('library_albums.id = :id', { id })
+            .getOne();
+
         const relatedAlbums = await AlbumRepository.createQueryBuilder('album')
             .leftJoinAndSelect('album.artist', 'artist')
             .where('album.id != :id and artist.id = :artistId', { id, artistId: album?.artist.id })
@@ -48,7 +54,7 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
 
         return res.json({
             success: true,
-            data: { ...album, relatedAlbums },
+            data: { ...album, liked: !!userLiked, relatedAlbums },
         });
     } catch (err) {
         return res.status(500).json({ success: false });

--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -43,9 +43,8 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
         const UserRepository = getRepository(User);
         const userLiked = await UserRepository.createQueryBuilder('user')
             .leftJoinAndSelect('user.libraryAlbums', 'library_albums')
-            .where('library_albums.id = :id', { id })
+            .where('user.id = :userId AND library_albums.id = :id', { userId, id })
             .getOne();
-
         const relatedAlbums = await AlbumRepository.createQueryBuilder('album')
             .leftJoinAndSelect('album.artist', 'artist')
             .where('album.id != :id and artist.id = :artistId', { id, artistId: album?.artist.id })

--- a/server/src/routes/artists/artists.controller.ts
+++ b/server/src/routes/artists/artists.controller.ts
@@ -54,7 +54,7 @@ const findOne = async (req: Request, res: Response, next: NextFunction) => {
         const UserRepository = getRepository(User);
         const userLiked = await UserRepository.createQueryBuilder('user')
             .leftJoinAndSelect('user.libraryArtists', 'library_artists')
-            .where('library_artists.id = :id', { id })
+            .where('user.id = :userId AND library_artists.id = :id', { userId, id })
             .getOne();
         return res.json({
             success: true,


### PR DESCRIPTION
### 📕 Issue Number

Close #432 #433 #434 #435 #449 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 각 데이터 상세 페이지에서 보관함저장, 삭제, 내 플레이리스트에 추가 동작 에러 수정 및 확인
- [x] 기타 페이지에서 각 데이터 보관함 저장, 삭제, 내플레이리스트에 추가 동작 에러 수정 및 확인
- [x] 비로그인 시 보관함 저장 등 권한 인증 실패 후 동작 처리 


### 📘 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 투데이 페이지에서 매거진 관련 동작
  - 민지님 pr 보니 이미 매거진에서 플레이리스트 관련 데이터를 불러오는 것 같아 제가 별도로 처리하기 보다 민지님 코드 활용하는 것이 좋을 것 같아 일단 보류하였습니다.

- 로그인 관련
  - 지영님이 해결해주신 부분 합쳐서 특이사항 말씀하셨던 부분까지 해결하였습니다

<br/><br/>
