### PR TITLE
[FE] upNextChnage 이벤트, playNow 이벤트 수집

### DIFF
--- a/client/components/molecules/PlayButton/PlayButton.tsx
+++ b/client/components/molecules/PlayButton/PlayButton.tsx
@@ -1,64 +1,66 @@
-import React from 'react'
+import React from 'react';
 import PlayTriangle from '../../atoms/PlayTriangle/PlayTriangle';
 import { StyledPlayButton, StyledCircle } from './PlayButton.styles';
 import { requestTracks } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
-import { withCookies, Cookies } from 'react-cookie';
+import { Cookies } from 'react-cookie';
 import { useSelector, useDispatch } from 'react-redux';
-import { addToUpNext, addToUpNextAndPlay } from 'reducers/musicPlayer';
+import { addToUpNextAndPlay } from 'reducers/musicPlayer';
+import useUpNextChangeEventLog from '@hooks/useUpNextChangeEventLog';
 
 interface playButtonProps {
     sort?: string;
     data?;
 }
 
-const PlayButton = ({sort, data}) => {
-    const cookies = new Cookies();      //request를 위해 새 쿠키 생성
+const PlayButton = ({ sort, data }) => {
+    const cookies = new Cookies(); //request를 위해 새 쿠키 생성
     const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
+    const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
 
-    const onClickHandler = async () => {
-        if(user.isLoggedIn){
-        let res; let tracks;
+    const handleClick = async () => {
+        if (!user.isLoggedIn) return;
+
+        let res, tracks;
         switch (sort) {
             case 'todayMagazine':
                 res = await requestTracks(`${apiUrl.magazine}/${data.id}`, cookies.get('token'));
-                tracks = res.playlist.tracks;
-                dispatch(addToUpNextAndPlay(tracks));
+                tracks = res?.playlist?.tracks;
                 break;
             case 'playlist':
                 res = await requestTracks(`${apiUrl.playlist}/${data.id}`, cookies.get('token'));
-                tracks = res.tracks;
-                dispatch(addToUpNextAndPlay(tracks));
+                tracks = res?.tracks;
                 break;
             case 'news':
                 res = await requestTracks(`${apiUrl.album}/${data.albumId}`, cookies.get('token'));
-                tracks = res.tracks;
-                dispatch(addToUpNextAndPlay(tracks));
+                tracks = res?.tracks;
                 break;
             case 'album':
                 res = await requestTracks(`${apiUrl.album}/${data.id}`, cookies.get('token'));
-                tracks = res.tracks;
-                dispatch(addToUpNextAndPlay(tracks));
+                tracks = res?.tracks;
                 break;
             case 'mixtape':
                 res = await requestTracks(`${apiUrl.playlist}/${data.id}`, cookies.get('token'));
-                tracks = res.tracks;
-                dispatch(addToUpNextAndPlay(tracks));
+                tracks = res?.tracks;
                 break;
             case 'station':
                 break;
             default:
                 return;
-        }}
-    }
+        }
+        if (!tracks || tracks.length === 0) return;
 
-    return(
-    <StyledPlayButton onClick={onClickHandler}>
-        <StyledCircle />
-        <PlayTriangle />
-    </StyledPlayButton>
-    )
+        dispatch(addToUpNextAndPlay(tracks));
+        logAddToUpnextEvent(tracks.map(({ id }) => id));
+    };
+
+    return (
+        <StyledPlayButton onClick={handleClick}>
+            <StyledCircle />
+            <PlayTriangle />
+        </StyledPlayButton>
+    );
 };
 
 export default PlayButton;

--- a/client/components/molecules/PlayButton/PlayButton.tsx
+++ b/client/components/molecules/PlayButton/PlayButton.tsx
@@ -17,6 +17,7 @@ const PlayButton = ({ sort, data }) => {
     const cookies = new Cookies(); //request를 위해 새 쿠키 생성
     const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
+    const { nowPlaying, playTime } = useSelector((state) => state.musicPlayer);
     const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
 
     const handleClick = async () => {
@@ -50,7 +51,10 @@ const PlayButton = ({ sort, data }) => {
         if (!tracks || tracks.length === 0) return;
 
         dispatch(addToUpNextAndPlay(tracks));
-        logAddToUpnextEvent(tracks.map(({ id }) => id));
+        logAddToUpnextEvent(
+            tracks.map(({ id }) => id),
+            { nowPlaying, playTime },
+        );
     };
 
     return (

--- a/client/components/molecules/PlayButton/PlayButton.tsx
+++ b/client/components/molecules/PlayButton/PlayButton.tsx
@@ -20,8 +20,6 @@ const PlayButton = ({ sort, data }) => {
     const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
 
     const handleClick = async () => {
-        if (!user.isLoggedIn) return;
-
         let res, tracks;
         switch (sort) {
             case 'todayMagazine':

--- a/client/components/molecules/PlayControllerButtons/index.tsx
+++ b/client/components/molecules/PlayControllerButtons/index.tsx
@@ -9,10 +9,8 @@ import SkipPreviousIcon from '@material-ui/icons/SkipPrevious';
 import SkipNextIcon from '@material-ui/icons/SkipNext';
 import { playPrevTrack, playNextTrack } from 'reducers/musicPlayer';
 import { useSelector, useDispatch } from 'react-redux';
+import usePlayNowEventLog from 'hooks/usePlayNowEventLog';
 
-// interface PlayControllerProps {
-//     playing: boolean;
-// }
 const Container = styled.div`
     display: flex;
     justify-content: center;
@@ -49,14 +47,35 @@ const SubIconWrapper = styled.button`
 const PlayControllerButtons = () => {
     const dispatch = useDispatch();
     const [playing, setPlaying] = useState(false);
+    const user = useSelector((state) => state.user);
+    const { nowPlaying, upNextTracks, playTime } = useSelector((state) => state.musicPlayer);
+    const logPlayNowEvent = usePlayNowEventLog({ userId: user.id });
+
+    const getNextTrackId = ({ upNextTracks, nowPlaying }) => {
+        const nowPlayingIdx = upNextTracks.findIndex((t) => t.id === nowPlaying.id);
+        const nextTrackIdx = nowPlayingIdx === upNextTracks.length - 1 ? nowPlayingIdx : nowPlayingIdx + 1;
+        return upNextTracks[nextTrackIdx].id;
+    };
+
+    const getPrevTrackId = ({ upNextTracks, nowPlaying }) => {
+        const nowPlayingIdx = upNextTracks.findIndex((t) => t.id === nowPlaying.id);
+        const prevTrackIdx = nowPlayingIdx == 0 ? nowPlayingIdx : nowPlayingIdx - 1;
+        return upNextTracks[prevTrackIdx].id;
+    };
 
     const toPrevTrack = () => {
         dispatch(playPrevTrack());
-    }
+        const prevTrackId = getPrevTrackId({ nowPlaying, upNextTracks });
+        if (prevTrackId === nowPlaying.id) return;
+        logPlayNowEvent(prevTrackId, nowPlaying.id, playTime, nowPlaying.playtime);
+    };
 
     const toNextTrack = () => {
         dispatch(playNextTrack());
-    }
+        const nextTrackId = getNextTrackId({ nowPlaying, upNextTracks });
+        if (nextTrackId === nowPlaying.id) return;
+        logPlayNowEvent(nextTrackId, nowPlaying.id, playTime, nowPlaying.playtime);
+    };
 
     return (
         <Container>
@@ -64,13 +83,13 @@ const PlayControllerButtons = () => {
                 <ShuffleIcon />
             </SubIconWrapper>
             <SkipIconWrapper>
-                <SkipPreviousIcon style={{ fontSize: '35px' }} onClick = { toPrevTrack }/>
+                <SkipPreviousIcon style={{ fontSize: '35px' }} onClick={toPrevTrack} />
             </SkipIconWrapper>
             <PlayIconWrapper onClick={() => setPlaying(!playing)}>
                 {playing ? <PauseIcon style={{ fontSize: '55px' }} /> : <PlayArrowIcon style={{ fontSize: '55px' }} />}
             </PlayIconWrapper>
             <SkipIconWrapper>
-                <SkipNextIcon style={{ fontSize: '35px' }} onClick = { toNextTrack }/>
+                <SkipNextIcon style={{ fontSize: '35px' }} onClick={toNextTrack} />
             </SkipIconWrapper>
             <SubIconWrapper>
                 <RepeatIcon />

--- a/client/components/molecules/PlayControllerButtons/index.tsx
+++ b/client/components/molecules/PlayControllerButtons/index.tsx
@@ -54,26 +54,26 @@ const PlayControllerButtons = () => {
     const getNextTrackId = ({ upNextTracks, nowPlaying }) => {
         const nowPlayingIdx = upNextTracks.findIndex((t) => t.id === nowPlaying.id);
         const nextTrackIdx = nowPlayingIdx === upNextTracks.length - 1 ? nowPlayingIdx : nowPlayingIdx + 1;
-        return upNextTracks[nextTrackIdx].id;
+        return upNextTracks[nextTrackIdx]?.id;
     };
 
     const getPrevTrackId = ({ upNextTracks, nowPlaying }) => {
         const nowPlayingIdx = upNextTracks.findIndex((t) => t.id === nowPlaying.id);
         const prevTrackIdx = nowPlayingIdx == 0 ? nowPlayingIdx : nowPlayingIdx - 1;
-        return upNextTracks[prevTrackIdx].id;
+        return upNextTracks[prevTrackIdx]?.id;
     };
 
     const toPrevTrack = () => {
         dispatch(playPrevTrack());
         const prevTrackId = getPrevTrackId({ nowPlaying, upNextTracks });
-        if (prevTrackId === nowPlaying.id) return;
+        if (!prevTrackId || prevTrackId === nowPlaying.id) return;
         logPlayNowEvent(prevTrackId, nowPlaying.id, playTime, nowPlaying.playtime);
     };
 
     const toNextTrack = () => {
         dispatch(playNextTrack());
         const nextTrackId = getNextTrackId({ nowPlaying, upNextTracks });
-        if (nextTrackId === nowPlaying.id) return;
+        if (!nextTrackId || nextTrackId === nowPlaying.id) return;
         logPlayNowEvent(nextTrackId, nowPlaying.id, playTime, nowPlaying.playtime);
     };
 

--- a/client/components/molecules/TrackPlayButton/index.tsx
+++ b/client/components/molecules/TrackPlayButton/index.tsx
@@ -3,7 +3,7 @@ import Image from '@components/atoms/Image/Image';
 import { ButtonContainer, Play } from './TrackPlayButton.styles';
 import { useSelector, useDispatch } from 'react-redux';
 import { addToUpNextAndPlay } from 'reducers/musicPlayer';
-import usePlayNowEvent from 'hooks/usePlayNowEventLog';
+import useUpNextChangeEventLog from '@hooks/useUpNextChangeEventLog';
 
 interface TrackPlayButtonProps {
     data;
@@ -14,12 +14,11 @@ const TrackPlayButton = ({ data, imgVariant }: TrackPlayButtonProps) => {
     const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
     const { nowPlaying, playTime } = useSelector((state) => state.musicPlayer);
-    const logPlayNowEvent = usePlayNowEvent({ userId: user.id });
+    const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
 
     const onClickPlayHandler = () => {
         dispatch(addToUpNextAndPlay([data]));
-        if (nowPlaying) logPlayNowEvent(nowPlaying.id, data.id, Math.floor((playTime * 100) / nowPlaying.playtime));
-        else logPlayNowEvent(data.id);
+        logAddToUpnextEvent([data.id], { nowPlaying, playTime });
     };
 
     const altImg = 'http://placehold.it/20x20';

--- a/client/components/molecules/TrackPlayButton/index.tsx
+++ b/client/components/molecules/TrackPlayButton/index.tsx
@@ -3,20 +3,29 @@ import Image from '@components/atoms/Image/Image';
 import { ButtonContainer, Play } from './TrackPlayButton.styles';
 import { useSelector, useDispatch } from 'react-redux';
 import { addToUpNextAndPlay } from 'reducers/musicPlayer';
+import usePlayNowEvent from 'hooks/usePlayNowEventLog';
 
 interface TrackPlayButtonProps {
     data;
     imgVariant?: 'trackRowCard' | 'trackInfo';
 }
+
 const TrackPlayButton = ({ data, imgVariant }: TrackPlayButtonProps) => {
     const dispatch = useDispatch();
+    const user = useSelector((state) => state.user);
+    const { nowPlaying, playTime } = useSelector((state) => state.musicPlayer);
+    const logPlayNowEvent = usePlayNowEvent({ userId: user.id });
+
     const onClickPlayHandler = () => {
         dispatch(addToUpNextAndPlay([data]));
-    }
+        if (nowPlaying) logPlayNowEvent(nowPlaying.id, data.id, Math.floor((playTime * 100) / nowPlaying.playtime));
+        else logPlayNowEvent(data.id);
+    };
+
     const altImg = 'http://placehold.it/20x20';
-    return(
+    return (
         <ButtonContainer onClick={onClickPlayHandler}>
-            <Image variant={imgVariant} src={data? data.album.imageUrl:altImg} />
+            <Image variant={imgVariant} src={data ? data.album.imageUrl : altImg} />
             <Play>
                 {
                     // TODO : svg 파일 분리
@@ -37,6 +46,7 @@ const TrackPlayButton = ({ data, imgVariant }: TrackPlayButtonProps) => {
                 </svg>
             </Play>
         </ButtonContainer>
-    )};
+    );
+};
 
 export default TrackPlayButton;

--- a/client/components/organisms/Cards/PlayerTrackCard/index.tsx
+++ b/client/components/organisms/Cards/PlayerTrackCard/index.tsx
@@ -7,6 +7,7 @@ import { Play } from '@components/molecules/TrackPlayButton/TrackPlayButton.styl
 import { PlayerTrackCardProp } from 'interfaces/props';
 import { useSelector, useDispatch } from 'react-redux';
 import { deleteTrackFromUpnext } from 'reducers/musicPlayer';
+import useUpNextChangeEvent from 'hooks/useUpNextChangeEventLog';
 
 const PlayerTrackCardContainer = styled.li`
     background-color: #141414;
@@ -24,20 +25,21 @@ const PlayerTrackCardContainer = styled.li`
     }
 `;
 const PlayerTrackCard = ({ data }: PlayerTrackCardProp) => {
-    const dispatch = useDispatch(); 
+    const dispatch = useDispatch();
+    const user = useSelector((state) => state.user);
+    const { logRemoveFromUpnextEvent } = useUpNextChangeEvent({ userId: user.id });
+
     const onClickDeleteHandler = () => {
         dispatch(deleteTrackFromUpnext(data.id));
-    }
+        logRemoveFromUpnextEvent([data.id]);
+    };
+
     return (
         <PlayerTrackCardContainer>
-            <TrackCard
-                data = { data } 
-                imgVariant="trackRowCard"
-                isDefault={true}
-                isTrack={true}
-            />
-            <IconButton variant="plainGreyRegular" icon={CloseIcon} onClick={onClickDeleteHandler}/>
+            <TrackCard data={data} imgVariant="trackRowCard" isDefault={true} isTrack={true} />
+            <IconButton variant="plainGreyRegular" icon={CloseIcon} onClick={onClickDeleteHandler} />
         </PlayerTrackCardContainer>
-    )};
+    );
+};
 
 export default PlayerTrackCard;

--- a/client/components/organisms/DetailHeader/index.tsx
+++ b/client/components/organisms/DetailHeader/index.tsx
@@ -72,7 +72,9 @@ interface DetailHeaderProps {
 const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
     const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
+    const { nowPlaying, playTime } = useSelector((state) => state.musicPlayer);
     const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
+
     const onAddUpNextAndPlayHandler = () => {
         if (sort === 'track') {
             dispatch(addToUpNextAndPlay([data]));
@@ -80,7 +82,10 @@ const DetailHeader = ({ sort, data }: DetailHeaderProps) => {
             return;
         }
         dispatch(addToUpNextAndPlay(data.tracks));
-        logAddToUpnextEvent(data.tracks.map(({ id }) => id));
+        logAddToUpnextEvent(
+            data.tracks.map(({ id }) => id),
+            { nowPlaying, playTime },
+        );
     };
 
     return (

--- a/client/components/organisms/FloatingSelectMenu/index.tsx
+++ b/client/components/organisms/FloatingSelectMenu/index.tsx
@@ -84,6 +84,7 @@ const PlayButtonContainer = styled.div`
 const FloatingSelectMenu = () => {
     const dispatch = useDispatch();
     const { tracks } = useSelector((state) => state.selectedTrack);
+    const { nowPlaying, playTime } = useSelector((state) => state.musicPlayer);
     const selectedTrackCount = tracks.length;
 
     const user = useSelector((state) => state.user);
@@ -92,7 +93,10 @@ const FloatingSelectMenu = () => {
     const onAddUpNextAndPlayHandler = () => {
         dispatch(addToUpNextAndPlay(tracks));
         dispatch(clearAllTracks());
-        logAddToUpnextEvent(tracks.map(({ id }) => id));
+        logAddToUpnextEvent(
+            tracks.map(({ id }) => id),
+            { nowPlaying, playTime },
+        );
     };
 
     const onAddUpNextHandler = () => {

--- a/client/components/organisms/HeaderButtonGroup/index.tsx
+++ b/client/components/organisms/HeaderButtonGroup/index.tsx
@@ -11,7 +11,9 @@ import Heart from '@components/atoms/Heart/Heart';
 
 import { HeaderButtonGroupProps } from 'interfaces/props';
 import { useContext, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { addToLibrary, deleteFromLibrary } from '@utils/apis';
+import useLikeEventLog from 'hooks/useLikeEventLog';
 import apiUrl from '@constants/apiUrl';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 
@@ -55,7 +57,10 @@ const contentsDropDownMenu = [
 
 const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGroupProps) => {
     const [likeStatus, setLikeStatus] = useState(liked);
+
     const componentInfo = useContext(ComponentInfoContext);
+    const user = useSelector((state) => state.user);
+    const logLikeEvent = useLikeEventLog({ userId: user.id });
     const data = componentInfo.data;
 
     const likeHandler = () => {
@@ -63,6 +68,7 @@ const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGrou
             addToLibrary(`${apiUrl.like}${data.type}s`, { data: { id: data.id } })
                 .then((data) => {
                     setLikeStatus(!likeStatus);
+                    logLikeEvent(true);
                 })
                 .catch((err) => {
                     console.log(err);
@@ -71,6 +77,7 @@ const HeaderButtonGroup = ({ sort, onAddUpNextHandler, liked }: HeaderButtonGrou
             deleteFromLibrary(`${apiUrl.like}${data.type}s/${data.id}`)
                 .then((data) => {
                     setLikeStatus(!likeStatus);
+                    logLikeEvent(false);
                 })
                 .catch((err) => {
                     console.log(err);

--- a/client/hooks/usePlayNowEventLog.ts
+++ b/client/hooks/usePlayNowEventLog.ts
@@ -1,0 +1,28 @@
+import { useContext } from 'react';
+import ComponentInfoContext from '@utils/context/ComponentInfoContext';
+
+import eventLogger from '@utils/eventLogger';
+
+interface PlayParams {
+    trackId?: number;
+    targetTrackId: number;
+    playingProgress?: number;
+}
+
+function usePlayNowEventLog({ userId }) {
+    const componentInfo = useContext(ComponentInfoContext);
+
+    const logPlayNowEvent = (trackId, targetTrackId, playingProgress: PlayParams) => {
+        eventLogger('PlayNow', {
+            userId,
+            trackId,
+            targetTrackId,
+            playingProgress,
+            ...componentInfo,
+        });
+    };
+
+    return logPlayNowEvent;
+}
+
+export default usePlayNowEventLog;

--- a/client/hooks/usePlayNowEventLog.ts
+++ b/client/hooks/usePlayNowEventLog.ts
@@ -3,20 +3,14 @@ import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 
 import eventLogger from '@utils/eventLogger';
 
-interface PlayParams {
-    trackId?: number;
-    targetTrackId: number;
-    playingProgress?: number;
-}
-
 function usePlayNowEventLog({ userId }) {
     const componentInfo = useContext(ComponentInfoContext);
 
-    const logPlayNowEvent = (trackId, targetTrackId, playingProgress: PlayParams) => {
+    const logPlayNowEvent = (targetTrackId, trackId?, playingProgress?) => {
         eventLogger('PlayNow', {
             userId,
-            trackId,
             targetTrackId,
+            trackId,
             playingProgress,
             ...componentInfo,
         });

--- a/client/hooks/usePlayNowEventLog.ts
+++ b/client/hooks/usePlayNowEventLog.ts
@@ -6,7 +6,8 @@ import eventLogger from '@utils/eventLogger';
 function usePlayNowEventLog({ userId }) {
     const componentInfo = useContext(ComponentInfoContext);
 
-    const logPlayNowEvent = (targetTrackId, trackId?, playingProgress?) => {
+    const logPlayNowEvent = (targetTrackId, trackId?, playtime?, totalPlaytime?) => {
+        const playingProgress = Math.floor((playtime * 100) / totalPlaytime);
         eventLogger('PlayNow', {
             userId,
             targetTrackId,

--- a/client/hooks/useUpNextChangeEventLog.ts
+++ b/client/hooks/useUpNextChangeEventLog.ts
@@ -14,7 +14,9 @@ function useUpNextChangeEvent({ userId }) {
             trackId,
             ...componentInfo,
         });
-        if (musicPlayer && musicPlayer.nowPlaying) {
+        // playNow event
+        if (!musicPlayer) return;
+        if (musicPlayer.nowPlaying) {
             const { nowPlaying, playTime } = musicPlayer;
             const playingProgress = Math.floor((playTime * 100) / nowPlaying.playtime);
             return logPlayNowEvent(trackId[0], musicPlayer.nowPlaying.id, playingProgress);

--- a/client/hooks/useUpNextChangeEventLog.ts
+++ b/client/hooks/useUpNextChangeEventLog.ts
@@ -1,17 +1,25 @@
 import { useContext } from 'react';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
+import usePlayNowEventLog from './usePlayNowEventLog';
 
 import eventLogger from '@utils/eventLogger';
 
 function useUpNextChangeEvent({ userId }) {
     const componentInfo = useContext(ComponentInfoContext);
+    const logPlayNowEvent = usePlayNowEventLog({ userId });
 
-    const logAddToUpnextEvent = (trackId: number[]) => {
+    const logAddToUpnextEvent = (trackId: number[], musicPlayer?) => {
         eventLogger('AddToUpnext', {
             userId,
             trackId,
             ...componentInfo,
         });
+        if (musicPlayer && musicPlayer.nowPlaying) {
+            const { nowPlaying, playTime } = musicPlayer;
+            const playingProgress = Math.floor((playTime * 100) / nowPlaying.playtime);
+            return logPlayNowEvent(trackId[0], musicPlayer.nowPlaying.id, playingProgress);
+        }
+        logPlayNowEvent(trackId[0]);
     };
 
     const logRemoveFromUpnextEvent = (trackId: number[]) => {

--- a/client/hooks/useUpNextChangeEventLog.ts
+++ b/client/hooks/useUpNextChangeEventLog.ts
@@ -18,8 +18,7 @@ function useUpNextChangeEvent({ userId }) {
         if (!musicPlayer) return;
         if (musicPlayer.nowPlaying) {
             const { nowPlaying, playTime } = musicPlayer;
-            const playingProgress = Math.floor((playTime * 100) / nowPlaying.playtime);
-            return logPlayNowEvent(trackId[0], musicPlayer.nowPlaying.id, playingProgress);
+            return logPlayNowEvent(trackId[0], nowPlaying.id, playTime, nowPlaying.playtime);
         }
         logPlayNowEvent(trackId[0]);
     };

--- a/client/interfaces/props.ts
+++ b/client/interfaces/props.ts
@@ -16,9 +16,9 @@ export interface TrackInfoProps {
 
 export interface InputProps {
     name?: string;
-    variant?: string;   
+    variant?: string;
     value?: string | undefined;
-    onChange? : (e : React.ChangeEvent<HTMLElement> ) => void | undefined
+    onChange?: (e: React.ChangeEvent<HTMLElement>) => void | undefined;
 }
 
 export interface MagazineCardProps {
@@ -40,8 +40,18 @@ export interface NewsCardProps {
 
 export interface ContentsThumbnailProps {
     data;
-    sort?: 'news' | 'mainMagazine' | 'normalMagazine' | 'recommendPlaylist' | 'normalPlaylist' | 'todayMagazine' | 'album' | 'playlist' | 'station' | 'mixtape' ;
-    contentId?: number | undefined
+    sort?:
+        | 'news'
+        | 'mainMagazine'
+        | 'normalMagazine'
+        | 'recommendPlaylist'
+        | 'normalPlaylist'
+        | 'todayMagazine'
+        | 'album'
+        | 'playlist'
+        | 'station'
+        | 'mixtape';
+    contentId?: number | undefined;
 }
 
 export interface MixtapeCardProps {
@@ -155,7 +165,7 @@ export interface DropdownMenuProps {
         handleClick?: (e: MouseEvent<HTMLElement>) => void;
     }[];
     children?: ReactNode;
-    state?: any
+    state?: any;
 }
 
 export interface CheckBoxProps {
@@ -168,7 +178,7 @@ export interface CheckBoxProps {
 export interface HeaderButtonGroupProps {
     sort?: 'track';
     onAddUpNextHandler?: any;
-    liked: boolean
+    liked: boolean;
 }
 
 export interface LyricModalProps {
@@ -186,11 +196,9 @@ export interface PlayControllerProps {
     displayHeaderHandler?;
 }
 
-
 export interface UserProps {
     id: number;
     name: string;
     isLoggedIn: boolean;
     profileUrl: string;
 }
-

--- a/client/pages/magazine/[id].tsx
+++ b/client/pages/magazine/[id].tsx
@@ -16,6 +16,7 @@ import ComponentInfoWrapper from '@utils/context/ComponentInfoWrapper';
 import { useSelector, useDispatch } from 'react-redux';
 import { addToUpNext, addToUpNextAndPlay } from 'reducers/musicPlayer';
 import useUpNextChangeEventLog from '@hooks/useUpNextChangeEventLog';
+import usePlayNowEvent from 'hooks/usePlayNowEventLog';
 
 const Container = styled.div`
     min-height: 1300px;
@@ -123,10 +124,14 @@ const MagazineDetail = ({ magazineData }) => {
     const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
     const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
+    const { nowPlaying, playTime } = useSelector((state) => state.musicPlayer);
 
     const onClickPlayHandler = () => {
         dispatch(addToUpNextAndPlay(magazineData.playlist.tracks));
-        logAddToUpnextEvent(magazineData.playlist.tracks.map(({ id }) => id));
+        logAddToUpnextEvent(
+            magazineData.playlist.tracks.map(({ id }) => id),
+            { nowPlaying, playTime },
+        );
     };
 
     return (

--- a/client/pages/magazine/[id].tsx
+++ b/client/pages/magazine/[id].tsx
@@ -15,6 +15,7 @@ import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 import ComponentInfoWrapper from '@utils/context/ComponentInfoWrapper';
 import { useSelector, useDispatch } from 'react-redux';
 import { addToUpNext, addToUpNextAndPlay } from 'reducers/musicPlayer';
+import useUpNextChangeEventLog from '@hooks/useUpNextChangeEventLog';
 
 const Container = styled.div`
     min-height: 1300px;
@@ -120,9 +121,13 @@ const WholeTrackTitleContainer = styled.div`
 
 const MagazineDetail = ({ magazineData }) => {
     const dispatch = useDispatch();
+    const user = useSelector((state) => state.user);
+    const { logAddToUpnextEvent } = useUpNextChangeEventLog({ userId: user.id });
+
     const onClickPlayHandler = () => {
         dispatch(addToUpNextAndPlay(magazineData.playlist.tracks));
-    }
+        logAddToUpnextEvent(magazineData.playlist.tracks.map(({ id }) => id));
+    };
 
     return (
         <ComponentInfoContext.Provider value={{ componentId: `${page.magazine}-${magazineData.id}` }}>
@@ -143,7 +148,13 @@ const MagazineDetail = ({ magazineData }) => {
                                 </A>
                             </PlaylistLinkConainer>
                             <ButtonContainer>
-                                <Button variant="primary" width="130" height="40" icon={PlayArrowIcon} onClick={onClickPlayHandler}>
+                                <Button
+                                    variant="primary"
+                                    width="130"
+                                    height="40"
+                                    icon={PlayArrowIcon}
+                                    onClick={onClickPlayHandler}
+                                >
                                     전체재생
                                 </Button>
                             </ButtonContainer>

--- a/server/src/models/PlayEvent.ts
+++ b/server/src/models/PlayEvent.ts
@@ -22,9 +22,9 @@ const playEventSchema = {
 
 const playNowEventSchema = {
     componentId: { type: String },
-    trackId: { type: Number, required: true },
+    trackId: { type: Number },
     targetTrackId: { type: Number, required: true },
-    playingProgress: { type: Number, required: true },
+    playingProgress: { type: Number },
 };
 
 const upNextChangeSchema = {

--- a/server/src/types/event.ts
+++ b/server/src/types/event.ts
@@ -64,9 +64,9 @@ interface IPlayEvent extends IEvent {
 
 interface IPlayNowEvent extends IEvent {
     componentId?: string,
-    trackId: number,
+    trackId?: number,
     targetTrackId: number,
-    playingProgress: number,
+    playingProgress?: number,
 }
 
 interface IUpNextChangeEvent extends IEvent {


### PR DESCRIPTION
### 📕 Issue Number

Close #425 , #459 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] usePlayNowEventLog 커스텀 훅 구현 -> useUpNextChange에서 사용하여 재생 목록 추가 시 첫번째 트랙 playNow 이벤트 수집
- [x] playButton, 매거진 상세 페이지 컴포넌트에서 추가적으로 재생목록 추가 이벤트 수집
- [x] 이전/다음곡 재생, TrackPlayButton 컴포넌트에서 PlayNow 이벤트 수집
- [x] removeFromUpnext 이벤트 수집


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 이제 play/pause 이벤트만 수집하면 될 것 같습니다 ! play 이벤트의 경우는 재생 버튼 클릭 했을 때 뿐만 아니라 현재 재생곡을 다 들어서 다음 곡으로 넘어갈 때도 발생해야 한다고 생각하는데 어떻게 생각하시나요 ? 

<br/><br/>
