### PR TITLE
play 이벤트 수집

### DIFF
--- a/client/components/molecules/PlayControllerButtons/index.tsx
+++ b/client/components/molecules/PlayControllerButtons/index.tsx
@@ -10,6 +10,7 @@ import SkipNextIcon from '@material-ui/icons/SkipNext';
 import { playPrevTrack, playNextTrack, playTrack, pauseTrack } from 'reducers/musicPlayer';
 import { useSelector, useDispatch } from 'react-redux';
 import usePlayNowEventLog from 'hooks/usePlayNowEventLog';
+import usePlayEventLog from 'hooks/usePlayEventLog';
 
 const Container = styled.div`
     display: flex;
@@ -50,6 +51,7 @@ const PlayControllerButtons = () => {
     const user = useSelector((state) => state.user);
     const { nowPlaying, upNextTracks, playTime } = useSelector((state) => state.musicPlayer);
     const logPlayNowEvent = usePlayNowEventLog({ userId: user.id });
+    const logPlayEvent = usePlayEventLog({ userId: user.id });
 
     const getNextTrackId = ({ upNextTracks, nowPlaying }) => {
         const nowPlayingIdx = upNextTracks.findIndex((t) => t.id === nowPlaying.id);
@@ -79,11 +81,13 @@ const PlayControllerButtons = () => {
 
     const playTrackHandler = () => {
         dispatch(playTrack());
-    }
+        if (nowPlaying) logPlayEvent(nowPlaying.id, true);
+    };
 
     const pauseTrackHandler = () => {
         dispatch(pauseTrack());
-    }
+        if (nowPlaying) logPlayEvent(nowPlaying.id, false);
+    };
 
     return (
         <Container>
@@ -94,8 +98,11 @@ const PlayControllerButtons = () => {
                 <SkipPreviousIcon style={{ fontSize: '35px' }} onClick={toPrevTrack} />
             </SkipIconWrapper>
             <PlayIconWrapper onClick={() => setPlaying(!playing)}>
-                {playing ? <PauseIcon style={{ fontSize: '55px' }} onClick = { pauseTrackHandler }/> :
-                 <PlayArrowIcon style={{ fontSize: '55px' }} onClick = { playTrackHandler }/>}
+                {playing ? (
+                    <PauseIcon style={{ fontSize: '55px' }} onClick={pauseTrackHandler} />
+                ) : (
+                    <PlayArrowIcon style={{ fontSize: '55px' }} onClick={playTrackHandler} />
+                )}
             </PlayIconWrapper>
             <SkipIconWrapper>
                 <SkipNextIcon style={{ fontSize: '35px' }} onClick={toNextTrack} />

--- a/client/components/molecules/PlayControllerButtons/index.tsx
+++ b/client/components/molecules/PlayControllerButtons/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import ShuffleIcon from '@material-ui/icons/Shuffle';
@@ -52,6 +52,10 @@ const PlayControllerButtons = () => {
     const { nowPlaying, upNextTracks, playTime } = useSelector((state) => state.musicPlayer);
     const logPlayNowEvent = usePlayNowEventLog({ userId: user.id });
     const logPlayEvent = usePlayEventLog({ userId: user.id });
+
+    useEffect(() => {
+        if (nowPlaying) logPlayEvent(nowPlaying.id, true);
+    }, [nowPlaying]);
 
     const getNextTrackId = ({ upNextTracks, nowPlaying }) => {
         const nowPlayingIdx = upNextTracks.findIndex((t) => t.id === nowPlaying.id);

--- a/client/hooks/usePlayEventLog.ts
+++ b/client/hooks/usePlayEventLog.ts
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+import ComponentInfoContext from '@utils/context/ComponentInfoContext';
+
+import eventLogger from '@utils/eventLogger';
+
+function usePlayEventLog({ userId }) {
+    const componentInfo = useContext(ComponentInfoContext);
+
+    const logPlayEvent = (trackId, isPlay) => {
+        eventLogger('Play', {
+            userId,
+            trackId,
+            isPlay,
+            ...componentInfo,
+        });
+    };
+
+    return logPlayEvent;
+}
+
+export default usePlayEventLog;


### PR DESCRIPTION
### 📕 Issue Number

Close #459 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 재생 / 멈춤 버튼 클릭 시 Play 이벤트 수집
- [x] 현재 재생 곡이 바뀌면 Play 이벤트 발생


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1 현재 재생 곡이 바뀔 때 play 이벤트가 발생하도록 해서 특정 곡을 선택해서 재생시켰을 때 PlayNow와 Play 이벤트 둘다 발생되게 됩니다. 이벤트가 중복되어 쌓이게 되지만 논리 상 틀리지는 않은 것 같아 이렇게 처리해도 될 .. 것 같습니다 ! 
- 특이 사항 2 play button을 통해 재생 목록에 추가할 때 자동으로 재생되었으면 좋을 것 같아요. 바로 재생되지 않는데 Play 이벤트가 발생하는 게 맞지 않는 것 같아 리덕스 공부해보고 수정해보도록 .. 노력하겠습니다 .. ! 

<br/><br/>
