### PR TITLE
차트 페이지 데이터 서버로부터 받아오도록 수정

### DIFF
--- a/client/components/molecules/GenreCard/GenreCard.tsx
+++ b/client/components/molecules/GenreCard/GenreCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Text from '../../atoms/Text';
+import { getRandomColor } from '@utils/color';
 
 const Card = styled.div`
     display: flex;
@@ -26,18 +27,19 @@ const Content = styled.div`
 `;
 
 interface GenreCardProps {
-    title: string;
-    href: string;
-    color: string;
+    id: number;
+    name: string;
+    href?: string;
+    color?: string;
 }
 
-const GenreCard = ({ title, href, color }: GenreCardProps) => (
+const GenreCard = ({ id, name, href, color }: GenreCardProps) => (
     <Card>
         {/* TODO : Link 컴포넌트로 감싸기 */}
         {/* <Link href={href}/> */}
-        <Bar color={color} />
+        <Bar color={color ? color : getRandomColor()} />
         <Content>
-            <Text>{title}</Text>
+            <Text>{name}</Text>
         </Content>
     </Card>
 );

--- a/client/components/organisms/CardLists/GenreCardList/index.tsx
+++ b/client/components/organisms/CardLists/GenreCardList/index.tsx
@@ -3,20 +3,6 @@ import styled from 'styled-components';
 import GenreCard from '@components/molecules/GenreCard/GenreCard';
 import CardScrollList from '@components/organisms/CardScrollList/CardScrollList';
 
-// TODO : DB 에서 장르 내용 받아오기
-const cards = [];
-for (let i = 0; i < 13; i++) {
-    const title = `test${i}`;
-    const href = '#';
-    const color = `#${Math.round(Math.random() * 0xffffff).toString(16)}`;
-    const card = {
-        title,
-        href,
-        color,
-    };
-    cards.push(card);
-}
-
 // TODO : refactor
 const getCardBundle = (cards) => {
     const bundle = [];
@@ -24,13 +10,9 @@ const getCardBundle = (cards) => {
     for (let i = 0; i < cards.length; i += 3) {
         bundle.push(
             <CardBundle>
-                <GenreCard title={cards[i].title} href={cards[i].href} color={cards[i].color} />
-                {cards[i + 1] ? (
-                    <GenreCard title={cards[i + 1].title} href={cards[i + 1].href} color={cards[i + 1].color} />
-                ) : null}
-                {cards[i + 2] ? (
-                    <GenreCard title={cards[i + 2].title} href={cards[i + 2].href} color={cards[i + 2].color} />
-                ) : null}
+                <GenreCard id={cards[i].id} name={cards[i].name} />
+                {cards[i + 1] ? <GenreCard id={cards[i + 1].id} name={cards[i + 1].name} /> : null}
+                {cards[i + 2] ? <GenreCard id={cards[i + 2].id} name={cards[i + 2].name} /> : null}
             </CardBundle>,
         );
     }
@@ -50,9 +32,9 @@ const CardBundle = styled.div`
     vertical-align: top;
 `;
 
-const GenreCardList = () => (
+const GenreCardList = ({ items }) => (
     <CardScrollList>
-        <StyledListContainer>{getCardBundle(cards)}</StyledListContainer>
+        <StyledListContainer>{getCardBundle(items)}</StyledListContainer>
     </CardScrollList>
 );
 

--- a/client/constants/apiUrl.ts
+++ b/client/constants/apiUrl.ts
@@ -1,7 +1,7 @@
 const host = 'http://localhost:4500';
-const eventHost = 'http://localhost:5500'
+const eventHost = 'http://localhost:5500';
 const baseUrl = `${host}/api`;
-const eventUrl = `${eventHost}/api`
+const eventUrl = `${eventHost}/api`;
 const apiUrl = {
     magazine: `${baseUrl}/magazines`,
     news: `${baseUrl}/news`,
@@ -19,6 +19,8 @@ const apiUrl = {
     addTracksToPlaylist: `${baseUrl}/playlists/tracks`,
     user: `${baseUrl}/users`,
     login: `${host}/auth`,
+    chart: `${baseUrl}/chart`,
+
     event: `${eventUrl}/events/`,
     playEvent: `${eventUrl}/play-events/`,
 };

--- a/client/constants/apiUrl.ts
+++ b/client/constants/apiUrl.ts
@@ -20,6 +20,7 @@ const apiUrl = {
     user: `${baseUrl}/users`,
     login: `${host}/auth`,
     chart: `${baseUrl}/chart`,
+    genre: `${baseUrl}/genres`,
 
     event: `${eventUrl}/events/`,
     playEvent: `${eventUrl}/play-events/`,

--- a/client/pages/chart.tsx
+++ b/client/pages/chart.tsx
@@ -1,13 +1,11 @@
 import styled from 'styled-components';
 import Text from '@components/atoms/Text';
-import { ChartCardProps } from '@interfaces/props';
 import ChartCardList from '@components/organisms/CardLists/ChartCardList';
 import GenreCardList from '@components/organisms/CardLists/GenreCardList';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
 import { request } from '@utils/apis';
 import apiUrl from '@constants/apiUrl';
-import { Track } from '@components/organisms/Library/LibraryHeader/LibraryHeader.stories';
 
 const Container = styled.div`
     min-height: 1300px;
@@ -33,34 +31,7 @@ const ChartContainer = styled.div`
     border-bottom: 1px #d7d7d7 solid;
 `;
 
-const ChartCards: ChartCardProps[] = Array(30).fill({
-    id: 5,
-    rank: 1,
-    title: '그냥',
-    album: {
-        id: 0,
-        imageUrl: 'https://musicmeta-phinf.pstatic.net/artist/002/826/2826154.jpg?type=ff300_300&v=20191231151906',
-    },
-    artist: {
-        id: 0,
-        name: '이영지',
-    },
-});
-
-const Albumdata = Array(9).fill({
-    id: 11,
-    title: '그냥',
-    description:
-        '이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.',
-    releaseDate: '2020-05-07',
-    imageUrl: 'https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg',
-    artist: {
-        id: 3,
-        name: '이영지',
-    },
-});
-
-const Chart = ({ chartData, recentAlbumData }) => {
+const Chart = ({ chartData, recentAlbumData, genreData }) => {
     return (
         <Container>
             <Header>
@@ -74,7 +45,7 @@ const Chart = ({ chartData, recentAlbumData }) => {
                 </ChartContainer>
                 <ChartContainer>
                     <CardListContainer title="장르 바로가기">
-                        <GenreCardList />
+                        <GenreCardList items={genreData} />
                     </CardListContainer>
                 </ChartContainer>
                 <CardListContainer title="최신 앨범" href="/album/sample">
@@ -86,7 +57,11 @@ const Chart = ({ chartData, recentAlbumData }) => {
 };
 
 export async function getServerSideProps() {
-    let [chartData, recentAlbumData] = await Promise.all([request(apiUrl.chart), request(apiUrl.album)]);
+    let [chartData, recentAlbumData, genreData] = await Promise.all([
+        request(apiUrl.chart),
+        request(apiUrl.album),
+        request(apiUrl.genre),
+    ]);
 
     if (!chartData) {
         return {
@@ -98,6 +73,7 @@ export async function getServerSideProps() {
         props: {
             chartData,
             recentAlbumData: recentAlbumData ? recentAlbumData : [],
+            genreData: genreData ? genreData : [],
         },
     };
 }

--- a/client/pages/chart.tsx
+++ b/client/pages/chart.tsx
@@ -60,7 +60,7 @@ const Albumdata = Array(9).fill({
     },
 });
 
-const Chart = ({ chartData }) => {
+const Chart = ({ chartData, recentAlbumData }) => {
     return (
         <Container>
             <Header>
@@ -72,23 +72,13 @@ const Chart = ({ chartData }) => {
                         <ChartCardList items={chartData} unit={5} />
                     </CardListContainer>
                 </ChartContainer>
-                {/* <ChartContainer>
-                    <CardListContainer title="국내 급상승" href="/">
-                        <ChartCardList items={ChartCards} unit={5} />
-                    </CardListContainer>
-                </ChartContainer>
-                <ChartContainer>
-                    <CardListContainer title="음악 검색 Top 100" href="/">
-                        <ChartCardList items={ChartCards} unit={5} />
-                    </CardListContainer>
-                </ChartContainer> */}
                 <ChartContainer>
                     <CardListContainer title="장르 바로가기">
                         <GenreCardList />
                     </CardListContainer>
                 </ChartContainer>
                 <CardListContainer title="최신 앨범" href="/album/sample">
-                    <ContentsCardList variant="album" items={Albumdata} />
+                    <ContentsCardList variant="album" items={recentAlbumData} />
                 </CardListContainer>
             </ContentsContainer>
         </Container>
@@ -96,7 +86,7 @@ const Chart = ({ chartData }) => {
 };
 
 export async function getServerSideProps() {
-    let chartData = await request(apiUrl.chart);
+    let [chartData, recentAlbumData] = await Promise.all([request(apiUrl.chart), request(apiUrl.album)]);
 
     if (!chartData) {
         return {
@@ -107,6 +97,7 @@ export async function getServerSideProps() {
     return {
         props: {
             chartData,
+            recentAlbumData: recentAlbumData ? recentAlbumData : [],
         },
     };
 }

--- a/client/pages/chart.tsx
+++ b/client/pages/chart.tsx
@@ -5,6 +5,9 @@ import ChartCardList from '@components/organisms/CardLists/ChartCardList';
 import GenreCardList from '@components/organisms/CardLists/GenreCardList';
 import CardListContainer from '@components/organisms/CardListContainer';
 import ContentsCardList from '@components/organisms/CardLists/ContentsCardList';
+import { request } from '@utils/apis';
+import apiUrl from '@constants/apiUrl';
+import { Track } from '@components/organisms/Library/LibraryHeader/LibraryHeader.stories';
 
 const Container = styled.div`
     min-height: 1300px;
@@ -41,22 +44,23 @@ const ChartCards: ChartCardProps[] = Array(30).fill({
     artist: {
         id: 0,
         name: '이영지',
-    }
+    },
 });
 
 const Albumdata = Array(9).fill({
     id: 11,
-    title: "그냥",
-    description: "이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.",
-    releaseDate: "2020-05-07",
-    imageUrl: "https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg",
+    title: '그냥',
+    description:
+        '이영지의 새로운 싱글앨범 <그냥>이 발매되었다.\n\n이번 곡은 아티스트 이영지가 그 동안 보여줘 왔던 기존 곡들과는 사뭇 다른 감성으로 우리에게 다가온다.\n\n2019년 11월 첫번째 발표곡 <암실>을 시작으로 약 6개월간 5곡의 작품을 발표한 이영지는 자신의 음악적 스펙트럼을 계속해서 확장해 나가며 다양한 음악을 우리에게 선사하고 있다.\n\n감성짙은 이번 싱글앨범 <그냥>은 우리에게 그녀의 또 다른 새로운 시작을 알리고 있다.',
+    releaseDate: '2020-05-07',
+    imageUrl: 'https://musicmeta-phinf.pstatic.net/album/004/551/4551646.jpg',
     artist: {
         id: 3,
-        name: "이영지"
-    }
+        name: '이영지',
+    },
 });
 
-const Chart = () => {
+const Chart = ({ chartData }) => {
     return (
         <Container>
             <Header>
@@ -64,11 +68,11 @@ const Chart = () => {
             </Header>
             <ContentsContainer>
                 <ChartContainer>
-                    <CardListContainer title="오늘 TOP 100" href="/">
-                        <ChartCardList items={ChartCards} unit={5} />
+                    <CardListContainer title="실시간 TOP 100" href="/">
+                        <ChartCardList items={chartData} unit={5} />
                     </CardListContainer>
                 </ChartContainer>
-                <ChartContainer>
+                {/* <ChartContainer>
                     <CardListContainer title="국내 급상승" href="/">
                         <ChartCardList items={ChartCards} unit={5} />
                     </CardListContainer>
@@ -77,7 +81,7 @@ const Chart = () => {
                     <CardListContainer title="음악 검색 Top 100" href="/">
                         <ChartCardList items={ChartCards} unit={5} />
                     </CardListContainer>
-                </ChartContainer>
+                </ChartContainer> */}
                 <ChartContainer>
                     <CardListContainer title="장르 바로가기">
                         <GenreCardList />
@@ -91,10 +95,20 @@ const Chart = () => {
     );
 };
 
-/*export const getServerSideProps = wrapper.getServerSideProps((context) => {
-    constext.store.dispatch({
-        type: LOAD_USER_REQUEST,
-    });
-})*/
+export async function getServerSideProps() {
+    let chartData = await request(apiUrl.chart);
+
+    if (!chartData) {
+        return {
+            notFound: true,
+        };
+    }
+
+    return {
+        props: {
+            chartData,
+        },
+    };
+}
 
 export default Chart;

--- a/client/utils/color.ts
+++ b/client/utils/color.ts
@@ -1,0 +1,12 @@
+function getRandomHex() {
+    return Math.floor(Math.random() * 255).toString(16);
+}
+
+function getRandomColor() {
+    const r = getRandomHex().padStart(2, '0');
+    const g = getRandomHex().padStart(2, '0');
+    const b = getRandomHex().padStart(2, '0');
+    return `#${r}${g}${b}`;
+}
+
+export { getRandomColor };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -160,6 +160,12 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/bcrypt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-3.0.0.tgz",
+      "integrity": "sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -510,8 +516,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -608,6 +613,20 @@
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
       "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -684,6 +703,15 @@
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-jB0yCBl4W/kVHM2whjfyqnxTmOHkCX4kHEa5nYKSoGeYe8YrjTYTc87/6bwt1g8cmV0QrbhKriETg9jWtcREhg==",
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-pre-gyp": "0.15.0"
       }
     },
     "binary-extensions": {
@@ -883,6 +911,11 @@
         "readdirp": "~3.5.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1027,6 +1060,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1064,6 +1102,11 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
       "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
       "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1128,6 +1171,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -1159,8 +1207,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1183,6 +1230,11 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
@@ -1197,6 +1249,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "4.0.2",
@@ -1791,6 +1848,14 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1814,6 +1879,54 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "generate-function": {
       "version": "2.3.1",
@@ -1963,6 +2076,11 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "has-yarn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
@@ -2023,6 +2141,14 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "import-fresh": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
@@ -2070,8 +2196,7 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -2132,8 +2257,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -2531,14 +2655,36 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
     },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -2707,10 +2853,68 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+    },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        }
+      }
     },
     "nodemon": {
       "version": "2.0.6",
@@ -2779,6 +2983,45 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
+    },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth": {
       "version": "0.9.15",
@@ -2871,6 +3114,25 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-cancelable": {
@@ -2978,6 +3240,14 @@
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
+      }
+    },
+    "passport-http-bearer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-http-bearer/-/passport-http-bearer-1.0.1.tgz",
+      "integrity": "sha1-FHRp6jZp4qhMYWfvmdu3fh8AmKg=",
+      "requires": {
+        "passport-strategy": "1.x.x"
       }
     },
     "passport-jwt": {
@@ -3195,7 +3465,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3345,7 +3614,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -3487,8 +3755,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "slash": {
       "version": "3.0.0",
@@ -3691,8 +3958,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -3725,6 +3991,27 @@
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
           }
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -4043,6 +4330,38 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "widest-line": {
       "version": "3.1.0",

--- a/server/src/routes/albums/albums.controller.ts
+++ b/server/src/routes/albums/albums.controller.ts
@@ -9,6 +9,8 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
         const albums = await AlbumRepository.createQueryBuilder('album')
             .leftJoinAndSelect('album.artist', 'artist')
             .select(['album', 'artist.id', 'artist.name'])
+            .orderBy('album.releaseDate', 'DESC')
+            .limit(20)
             .getMany();
 
         return res.json({

--- a/server/src/routes/chart/chart.controller.ts
+++ b/server/src/routes/chart/chart.controller.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+
+import Track from '../../models/Track';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const TrackRepository = getRepository(Track);
+
+        const tracks = await TrackRepository.createQueryBuilder('track')
+            .leftJoinAndSelect('track.album', 'album')
+            .leftJoinAndSelect('track.artist', 'artist')
+            .leftJoin('track.likeUsers', 'likeUsers')
+            .select([
+                'track.id',
+                'track.title',
+                'artist.id',
+                'artist.name',
+                'album.id',
+                'album.imageUrl',
+            ])
+            .addSelect('COUNT(likeUsers.id)', 'userLikesCount')
+            .groupBy('track.id')
+            .orderBy('userLikesCount', 'DESC')
+            .limit(50)
+            .getMany();
+
+        return res.json({
+            success: !!tracks,
+            data: tracks || [],
+        });
+    } catch (err) {
+        return res.status(500).json({
+            success: false,
+        });
+    }
+};
+
+export { list };

--- a/server/src/routes/chart/chart.controller.ts
+++ b/server/src/routes/chart/chart.controller.ts
@@ -7,7 +7,7 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const TrackRepository = getRepository(Track);
 
-        const tracks = await TrackRepository.createQueryBuilder('track')
+        let tracks = await TrackRepository.createQueryBuilder('track')
             .leftJoinAndSelect('track.album', 'album')
             .leftJoinAndSelect('track.artist', 'artist')
             .leftJoin('track.likeUsers', 'likeUsers')
@@ -22,8 +22,10 @@ const list = async (req: Request, res: Response, next: NextFunction) => {
             .addSelect('COUNT(likeUsers.id)', 'userLikesCount')
             .groupBy('track.id')
             .orderBy('userLikesCount', 'DESC')
-            .limit(50)
+            .limit(100)
             .getMany();
+
+        tracks = tracks?.map((track, idx) => ({ ...track, rank: idx + 1 }));
 
         return res.json({
             success: !!tracks,

--- a/server/src/routes/chart/index.ts
+++ b/server/src/routes/chart/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as chartController from './chart.controller';
+
+const router = express.Router();
+
+router.get('/', chartController.list);
+
+export default router;

--- a/server/src/routes/genres/genres.controller.ts
+++ b/server/src/routes/genres/genres.controller.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+import { getRepository } from 'typeorm';
+
+import Genre from '../../models/Genre';
+
+const list = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const GenreRepository = getRepository(Genre);
+        const genres = await GenreRepository.find();
+
+        return res.json({
+            success: true,
+            data: [...genres],
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false });
+    }
+};
+
+export { list };

--- a/server/src/routes/genres/index.ts
+++ b/server/src/routes/genres/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as genreController from './genres.controller';
+
+const router = express.Router();
+
+router.get('/', genreController.list);
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -8,6 +8,7 @@ import playlistRouter from './playlists';
 import albumRouter from './albums';
 import trackRouter from './tracks';
 import mixtapeRouter from './mixtapes';
+import chartRouter from './chart';
 import { authenticateJWT, checkAuth } from '../middlewares/auth';
 
 const router = express.Router();
@@ -22,5 +23,6 @@ router.use('/playlists', playlistRouter);
 router.use('/tracks', trackRouter);
 router.use('/albums', albumRouter);
 router.use('/mixtapes', mixtapeRouter);
+router.use('/chart', chartRouter);
 
 export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -9,6 +9,7 @@ import albumRouter from './albums';
 import trackRouter from './tracks';
 import mixtapeRouter from './mixtapes';
 import chartRouter from './chart';
+import genreRouter from './genres';
 import { authenticateJWT, checkAuth } from '../middlewares/auth';
 
 const router = express.Router();
@@ -24,5 +25,6 @@ router.use('/tracks', trackRouter);
 router.use('/albums', albumRouter);
 router.use('/mixtapes', mixtapeRouter);
 router.use('/chart', chartRouter);
+router.use('/genres', genreRouter);
 
 export default router;


### PR DESCRIPTION
### 📕 Issue Number

Close #376 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] GET /api/chart 좋아요한 유저 수로 정렬한 트랙 데이터(limit 100) 반환하는 api 구현
- [x] GET /api/genres 장르 조회 api 구현
- [x] 앨범 조회 api 최신 앨범 순으로 정렬한 데이터 반환하도록 수정
- [x] 장르 페이지에서 차트 데이터, 장르 데이터, 최신 앨범 데이터 불러와서 렌더링하도록 수정 


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br/><br/>
