### PR TITLE
[iOS] 보관함 화면에서 곡에대한 메뉴 화면이 정상적으로 동작하지 않던 문제 해결

### DIFF
--- a/MiniVibe/MiniVibe/Library.swift
+++ b/MiniVibe/MiniVibe/Library.swift
@@ -31,15 +31,8 @@ struct Library: View {
                                 let tracks = viewModel.state.likedTracks
                                 ForEach(tracks, id: \.self) { track in
                                     TrackRowC(viewModel: .init(track: track,
-                                                               eventLogger: MiniVibeApp.eventLogger)) { _ in
-                                        viewModel.send(.tapMenuButton)
-                                    }
-                                    .fullScreenCover(isPresented: $viewModel.state.isMenuOpen) {
-                                        PlayerMenu(viewModel: .init(track: track,
-                                                                    eventLogger: MiniVibeApp.eventLogger))
-                                            .logTransition(identifier: .playerMenu(id: trackinfo.id),
-                                                           componentId: .trackMenuButton
-                                            )
+                                                               eventLogger: MiniVibeApp.eventLogger)) {
+                                        viewModel.send(.tapMenuButton(track: $0))
                                     }
                                 }
                             }
@@ -49,6 +42,17 @@ struct Library: View {
                     }
                 }
                 .navigationBarHidden(true)
+                .fullScreenCover(isPresented: $viewModel.state.isMenuOpen) {
+                    if let track = viewModel.state.tappedTrack {
+                        PlayerMenu(viewModel: track)
+                            .logTransition(identifier: .playerMenu(id: trackinfo.id),
+                                           componentId: .trackMenuButton
+                            )
+                            .onDisappear {
+                                viewModel.send(.appear)
+                            }
+                    }
+                }
             }
         }
         .onAppear {

--- a/MiniVibe/MiniVibe/ViewModels/LibraryViewModel.swift
+++ b/MiniVibe/MiniVibe/ViewModels/LibraryViewModel.swift
@@ -13,12 +13,13 @@ final class LibraryViewModel: ObservableObject {
     
     enum Input {
         case appear
-        case tapMenuButton
+        case tapMenuButton(track: TrackViewModel)
     }
     
     struct State {
         var likedTracks = [TrackInfo]()
         var isMenuOpen = false
+        var tappedTrack: TrackViewModel?
     }
     
     @Published var state = State()
@@ -36,8 +37,9 @@ final class LibraryViewModel: ObservableObject {
         switch input {
         case .appear:
             load()
-        case .tapMenuButton:
+        case let .tapMenuButton(track):
             state.isMenuOpen = true
+            state.tappedTrack = track
         }
     }
     

--- a/MiniVibe/MiniVibeTests/LibraryViewModelTests.swift
+++ b/MiniVibe/MiniVibeTests/LibraryViewModelTests.swift
@@ -59,15 +59,26 @@ final class LibraryViewModelTests: XCTestCase {
             expectation.fulfill()
         }
         let viewModel = LibraryViewModel(usecase: usecase, eventLogger: eventLogger)
+        let tappedTrack = TrackViewModel(track: .init(id: 0,
+                                                         title: "",
+                                                         lyrics: "",
+                                                         albumId: 0,
+                                                         album: .init(id: 0,
+                                                                      title: "",
+                                                                      imageUrl: ""),
+                                                         artist: .init(id: 0,
+                                                                       name: ""),
+                                                         liked: 0))
+        
         viewModel.$state
             .sink { state in
-                if state.isMenuOpen {
+                if state.isMenuOpen,
+                   state.tappedTrack == tappedTrack {
                     expectation.fulfill()
                 }
             }
             .store(in: &cancellables)
         
-        viewModel.send(.tapMenuButton)
+        viewModel.send(.tapMenuButton(track: tappedTrack))
     }
-
 }


### PR DESCRIPTION
### 📕 Issue Number


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 메뉴 버튼이 눌릴 때 해당 곡에 대한 TrackViewModel을 넘겨 PlayerMenu로 전달하도록 구조 수정
- [x] 수정된 LibraryViewModel의 구조에 맞게 테스트코드 수정


### 📘 작업 유형

- [x] 버그 수정


### 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [x] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>
