### PR TITLE
[FE] Fix: LoginForm, NaverLoginButton 컴포넌트 분리

### DIFF
--- a/client/components/atoms/NaverLoginButton/index.tsx
+++ b/client/components/atoms/NaverLoginButton/index.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import apiUrl from '@constants/apiUrl';
+import useClickEventLog from '@hooks/useClickEventLog';
+
+const NaverLogin = styled.a`
+    display: block;
+    margin-top: 40px;
+`;
+
+const NaverLoginButton = () => {
+    const naverClick = useClickEventLog({ userId: null, href: `${apiUrl.login}/naver-login` });
+
+    return (
+        <NaverLogin id="naver-login" href={`${apiUrl.login}/naver-login`} onClick={naverClick}>
+            <img
+                height="50"
+                src="https://user-images.githubusercontent.com/60503734/102323140-717b2300-3fc3-11eb-886d-e124e75d3169.PNG"
+                alt="네이버로 로그인"
+            />
+        </NaverLogin>
+    );
+};
+
+export default NaverLoginButton;

--- a/client/components/molecules/LoginForm/index.tsx
+++ b/client/components/molecules/LoginForm/index.tsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+import apiUrl from '@constants/apiUrl';
+import useClickEventLog from '@hooks/useClickEventLog';
+
+const Form = styled.form`
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    justify-content: center;
+`;
+
+const LoginInput = styled.input`
+    background-color: transperant;
+    display: block;
+    margin: 0 auto;
+    width: 231.19px;
+    height: 40px;
+    margin-bottom: 10px;
+    &:focus {
+        outline: none;
+    }
+`;
+
+const LoginButton = styled.input`
+    focus: none;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 9px 15px;
+    color: black;
+    border: 1px solid #d7d7d7;
+    background-color: white;
+    width: 231.19px;
+    height: 50px;
+    border-radius: 4px;
+    box-shadow: none;
+    cursor: pointer;
+    font-size: 15px;
+    line-height: 1;
+    outline: none;
+    -webkit-text-decoration: none;
+    text-decoration: none;
+    white-space: nowrap;
+`;
+
+const Title = styled.p`
+    font-size: 20px;
+    font-weight: 700;
+`;
+
+const LoginForm = () => {
+    const localClick = useClickEventLog({ userId: null, href: `${apiUrl.login}/local-login` });
+
+    return (
+        <Form action={`${apiUrl.login}/local-login`} method="post">
+            <Title>miniVIBE 로그인</Title>
+            <LoginInput type="email" name="email" placeholder="이메일을 입력해주세요" />
+            <LoginInput id="pw" type="password" name="pw" placeholder="비밀번호를 입력해주세요" />
+            <LoginButton id="local-login" type="submit" value="로그인" onClick={localClick} />
+        </Form>
+    );
+};
+
+export default LoginForm;

--- a/client/pages/login/index.tsx
+++ b/client/pages/login/index.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import apiUrl from '@constants/apiUrl';
 import ComponentInfoContext from '@utils/context/ComponentInfoContext';
 import { componentType, contentType } from '@constants/identifier';
-import useClickEventLog from '@hooks/useClickEventLog';
 import { Cookies } from 'react-cookie';
 import { useEffect } from 'react';
 import ComponentInfoWrapper from '@utils/context/ComponentInfoWrapper';
 import Button from '@components/atoms/Button';
+import NaverLoginButton from '@components/atoms/NaverLoginButton';
+import LoginForm from '@components/molecules/LoginForm';
 import Link from 'next/link';
 import HeadsetIcon from '@material-ui/icons/Headset';
 
@@ -26,60 +26,7 @@ const LoginContainer = styled.div`
     padding-bottom: 200px;
 `;
 
-const Form = styled.form`
-    display: flex;
-    flex-flow: column;
-    align-items: center;
-    justify-content: center;
-`;
-
-const LoginInput = styled.input`
-    background-color: transperant;
-    display: block;
-    margin: 0 auto;
-    width: 231.19px;
-    height: 40px;
-    margin-bottom: 10px;
-    &:focus {
-        outline: none;
-    }
-`;
-
-const LoginButton = styled.input`
-    focus: none;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    padding: 9px 15px;
-    color: black;
-    border: 1px solid #d7d7d7;
-    background-color: white;
-    width: 231.19px;
-    height: 50px;
-    border-radius: 4px;
-    box-shadow: none;
-    cursor: pointer;
-    font-size: 15px;
-    line-height: 1;
-    outline: none;
-    -webkit-text-decoration: none;
-    text-decoration: none;
-    white-space: nowrap;
-`;
-
-const NaverLogin = styled.a`
-    display: block;
-    margin-top: 40px;
-`;
-
-const Title = styled.p`
-    font-size: 20px;
-    font-weight: 700;
-`;
-
 const Login = () => {
-    const localClick = useClickEventLog({ userId: null, href: `${apiUrl.login}/local-login` });
-    const naverClick = useClickEventLog({ userId: null, href: `${apiUrl.login}/naver-login` });
     const cookies = new Cookies();
     useEffect(() => {
         if (cookies.get('fail')) {
@@ -92,21 +39,10 @@ const Login = () => {
         <ComponentInfoContext.Provider value={{ componentId: componentType.loginForm }}>
             <LoginContainer>
                 <ComponentInfoWrapper componentId={contentType.localLogin}>
-                    <Form action={`${apiUrl.login}/local-login`} method="post">
-                        <Title>miniVIBE 로그인</Title>
-                        <LoginInput type="email" name="email" placeholder="이메일을 입력해주세요" />
-                        <LoginInput id="pw" type="password" name="pw" placeholder="비밀번호를 입력해주세요" />
-                        <LoginButton id="local-login" type="submit" value="로그인" onClick={localClick} />
-                    </Form>
+                    <LoginForm />
                 </ComponentInfoWrapper>
                 <ComponentInfoWrapper componentId={contentType.naverLogin}>
-                    <NaverLogin id="naver-login" href={`${apiUrl.login}/naver-login`} onClick={naverClick}>
-                        <img
-                            height="50"
-                            src="https://user-images.githubusercontent.com/60503734/102323140-717b2300-3fc3-11eb-886d-e124e75d3169.PNG"
-                            alt="네이버로 로그인"
-                        />
-                    </NaverLogin>
+                    <NaverLoginButton />
                 </ComponentInfoWrapper>
                 <ComponentInfoWrapper componentId={contentType.join}>
                     <Link href="/join">


### PR DESCRIPTION


### 📕 Issue Number

Close #


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [ ] 로그인 버튼/ 네이버 로그인 버튼 클릭 이벤트 전송시 400 뜨는 문제 - 컴포넌트 분리하여 해결


### 📘 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트


### 📋 체크리스트

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?
      <br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 로그인 버튼 클릭 시 componentId가 ""로 설정되어 이벤트 전송 응답 400으로 오는 오류
-  login page 컴포넌트 내에서 component context를 제공하는데 클릭 이벤트 커스텀 훅에서 useContext했을 때 해당 컴포넌트에서의 context info는 정의되어 있지 않아(부모로부터 받은 component context가 없기 때문에) componentId가 빈 문자열이 되는 문제 하위 컴포넌트 분리하고 각 컴포넌트에서 이벤트 커스텀 훅 사용하여 문제 해결 

<br/><br/>
